### PR TITLE
Add lock-on component

### DIFF
--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -32,16 +32,17 @@ public class ALSReplicated : ModuleRules
 			
 		
 		PrivateDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"Core",
-				"CoreUObject",
-				"Engine",
-				"Slate",
-				"SlateCore",
-				// ... add private dependencies that you statically link with here ...	
-			}
-			);
+                        new string[]
+                        {
+                                "Core",
+                                "CoreUObject",
+                                "Engine",
+                                "Slate",
+                                "SlateCore",
+                                "UMG",
+                                // ... add private dependencies that you statically link with here ...
+                        }
+                        );
 		
 		
 		DynamicallyLoadedModuleNames.AddRange(

--- a/Source/ALSReplicated/Private/ALSBaseCharacter.cpp
+++ b/Source/ALSReplicated/Private/ALSBaseCharacter.cpp
@@ -2,13 +2,15 @@
 
 
 #include "ALSBaseCharacter.h"
+#include "LockOnComponent.h"
 
 // Sets default values
 AALSBaseCharacter::AALSBaseCharacter(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer.SetDefaultSubobjectClass<UALSCharacterMovementComponent>(CharacterMovementComponentName))
 {
- 	// Set this character to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
-	PrimaryActorTick.bCanEverTick = true;
+        // Set this character to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+        PrimaryActorTick.bCanEverTick = true;
 
+        LockOnComponent = CreateDefaultSubobject<ULockOnComponent>(TEXT("LockOnComponent"));
 }
 
 // Called when the game starts or when spawned

--- a/Source/ALSReplicated/Private/LockOnComponent.cpp
+++ b/Source/ALSReplicated/Private/LockOnComponent.cpp
@@ -1,0 +1,81 @@
+#include "LockOnComponent.h"
+#include "GameFramework/Actor.h"
+#include "Camera/PlayerCameraManager.h"
+#include "GameFramework/PlayerController.h"
+
+ULockOnComponent::ULockOnComponent()
+{
+        PrimaryComponentTick.bCanEverTick = false;
+        SetIsReplicatedByDefault(true);
+}
+
+void ULockOnComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+        Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+        DOREPLIFETIME(ULockOnComponent, bIsLockedOn);
+        DOREPLIFETIME(ULockOnComponent, LockedActor);
+}
+
+void ULockOnComponent::ToggleLockOn()
+{
+        if (GetOwnerRole() < ROLE_Authority)
+        {
+                ServerToggleLockOn();
+                return;
+        }
+
+        DoToggleLockOn();
+}
+
+void ULockOnComponent::ServerToggleLockOn_Implementation()
+{
+        DoToggleLockOn();
+}
+
+void ULockOnComponent::DoToggleLockOn()
+{
+        if (bIsLockedOn)
+        {
+                bIsLockedOn = false;
+                LockedActor = nullptr;
+                return;
+        }
+
+        PerformLineTrace();
+}
+
+void ULockOnComponent::PerformLineTrace()
+{
+        AActor* OwnerActor = GetOwner();
+        if (!OwnerActor)
+        {
+                return;
+        }
+
+        APlayerController* PC = Cast<APlayerController>(OwnerActor->GetInstigatorController());
+        if (!PC)
+        {
+                return;
+        }
+
+        FVector ViewLocation;
+        FRotator ViewRotation;
+        PC->GetPlayerViewPoint(ViewLocation, ViewRotation);
+
+        const FVector End = ViewLocation + ViewRotation.Vector() * 10000.0f;
+
+        FHitResult Hit;
+        FCollisionQueryParams Params;
+        Params.AddIgnoredActor(OwnerActor);
+
+        if (GetWorld()->LineTraceSingleByChannel(Hit, ViewLocation, End, ECC_Pawn, Params))
+        {
+                AActor* HitActor = Hit.GetActor();
+                if (HitActor && HitActor != OwnerActor)
+                {
+                        LockedActor = HitActor;
+                        bIsLockedOn = true;
+                }
+        }
+}
+

--- a/Source/ALSReplicated/Public/ALSBaseCharacter.h
+++ b/Source/ALSReplicated/Public/ALSBaseCharacter.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Character.h"
 #include "ALSCharacterMovementComponent.h"
+#include "LockOnComponent.h"
 #include "Net/UnrealNetwork.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "Animation/AnimInstance.h"
@@ -35,8 +36,11 @@ public:
 	UPROPERTY(BlueprintReadWrite, Replicated, Category="ALS || Rotation")
 	FRotator ControlRotation = GetControlRotation();
 
-	UPROPERTY(BlueprintReadWrite, Category="ALS || Component")
-	UALSCharacterMovementComponent* ALSCharacterMovement;
+        UPROPERTY(BlueprintReadWrite, Category="ALS || Component")
+        UALSCharacterMovementComponent* ALSCharacterMovement;
+
+        UPROPERTY(BlueprintReadWrite, Category="ALS || Component")
+        ULockOnComponent* LockOnComponent;
 
 };
 

--- a/Source/ALSReplicated/Public/LockOnComponent.h
+++ b/Source/ALSReplicated/Public/LockOnComponent.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "LockOnComponent.generated.h"
+
+class UUserWidget;
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API ULockOnComponent : public UActorComponent
+{
+        GENERATED_BODY()
+
+public:
+        ULockOnComponent();
+
+        virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+        UFUNCTION(BlueprintCallable, Category="LockOn")
+        void ToggleLockOn();
+
+protected:
+        UFUNCTION(Server, Reliable)
+        void ServerToggleLockOn();
+
+        void DoToggleLockOn();
+        void PerformLineTrace();
+
+        UPROPERTY(Replicated)
+        bool bIsLockedOn = false;
+
+        UPROPERTY(Replicated)
+        AActor* LockedActor = nullptr;
+
+public:
+        UPROPERTY(EditDefaultsOnly, Category="LockOn")
+        TSubclassOf<UUserWidget> TargetWidgetClass;
+};
+


### PR DESCRIPTION
## Summary
- add `LockOnComponent` with replication and camera trace logic
- expose Blueprint callable `ToggleLockOn`
- integrate lock-on component into `AALSBaseCharacter`
- add optional `TargetWidgetClass` property for UI reticle
- enable UMG dependency for the plugin

## Testing
- `true` (no tests provided)


------
https://chatgpt.com/codex/tasks/task_e_6867d37331048331ad87fd0646bad4dd