### PR TITLE
Add cinematic camera component

### DIFF
--- a/Source/ALSReplicated/Public/CinematicCameraComponent.cpp
+++ b/Source/ALSReplicated/Public/CinematicCameraComponent.cpp
@@ -1,0 +1,82 @@
+#include "CinematicCameraComponent.h"
+#include "Camera/PlayerCameraManager.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Actor.h"
+
+UCinematicCameraComponent::UCinematicCameraComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    TargetArmLength = 300.f;
+    DesiredArmLength = TargetArmLength;
+}
+
+void UCinematicCameraComponent::SwitchShoulder()
+{
+    bRightShoulder = !bRightShoulder;
+    OnShoulderSwitched(bRightShoulder);
+}
+
+void UCinematicCameraComponent::SetDesiredArmLength(float Length)
+{
+    DesiredArmLength = Length;
+    OnZoomChanged(Length);
+}
+
+void UCinematicCameraComponent::EnterFocusMode(AActor* Target)
+{
+    FocusTarget = Target;
+    bFocusMode = FocusTarget != nullptr;
+    if (bFocusMode)
+    {
+        OnFocusModeStarted(FocusTarget);
+    }
+}
+
+void UCinematicCameraComponent::ExitFocusMode()
+{
+    FocusTarget = nullptr;
+    if (bFocusMode)
+    {
+        bFocusMode = false;
+        OnFocusModeEnded();
+    }
+}
+
+void UCinematicCameraComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    TargetArmLength = FMath::FInterpTo(TargetArmLength, DesiredArmLength, DeltaTime, ZoomInterpSpeed);
+
+    FVector DesiredOffset(0.f, bRightShoulder ? ShoulderOffset : -ShoulderOffset, 0.f);
+    if (bEnableLag)
+    {
+        SocketOffset = FMath::VInterpTo(SocketOffset, DesiredOffset, DeltaTime, LagSpeed);
+    }
+    else
+    {
+        SocketOffset = DesiredOffset;
+    }
+
+    if (bFocusMode && FocusTarget)
+    {
+        FVector Direction = FocusTarget->GetActorLocation() - GetComponentLocation();
+        FRotator DesiredRot = Direction.Rotation();
+        SetWorldRotation(FMath::RInterpTo(GetComponentRotation(), DesiredRot, DeltaTime, LagSpeed));
+    }
+
+    if (bUsePostProcess)
+    {
+        if (AActor* OwnerActor = GetOwner())
+        {
+            if (APlayerController* PC = Cast<APlayerController>(OwnerActor->GetInstigatorController()))
+            {
+                if (APlayerCameraManager* PCM = PC->PlayerCameraManager)
+                {
+                    PCM->AddCachedPPBlend(PostProcessSettings, PostProcessBlendWeight);
+                }
+            }
+        }
+    }
+}
+

--- a/Source/ALSReplicated/Public/CinematicCameraComponent.h
+++ b/Source/ALSReplicated/Public/CinematicCameraComponent.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SpringArmComponent.h"
+#include "Engine/Scene.h"
+#include "CinematicCameraComponent.generated.h"
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UCinematicCameraComponent : public USpringArmComponent
+{
+    GENERATED_BODY()
+
+public:
+    UCinematicCameraComponent();
+
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    UFUNCTION(BlueprintCallable, Category="Camera")
+    void SwitchShoulder();
+
+    UFUNCTION(BlueprintCallable, Category="Camera")
+    void SetDesiredArmLength(float Length);
+
+    UFUNCTION(BlueprintCallable, Category="Camera")
+    void EnterFocusMode(AActor* Target);
+
+    UFUNCTION(BlueprintCallable, Category="Camera")
+    void ExitFocusMode();
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Camera")
+    void OnShoulderSwitched(bool bRight);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Camera")
+    void OnZoomChanged(float NewLength);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Camera")
+    void OnFocusModeStarted(AActor* Target);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Camera")
+    void OnFocusModeEnded();
+
+protected:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Shoulder")
+    float ShoulderOffset = 50.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Shoulder")
+    bool bRightShoulder = true;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lag")
+    bool bEnableLag = true;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lag", meta=(EditCondition="bEnableLag"))
+    float LagSpeed = 10.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Zoom")
+    float ZoomInterpSpeed = 5.f;
+
+    UPROPERTY(BlueprintReadWrite, Category="Zoom")
+    float DesiredArmLength = 300.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess")
+    bool bUsePostProcess = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess", meta=(EditCondition="bUsePostProcess"))
+    FPostProcessSettings PostProcessSettings;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess", meta=(EditCondition="bUsePostProcess"))
+    float PostProcessBlendWeight = 1.f;
+
+    UPROPERTY(BlueprintReadWrite, Category="Focus")
+    bool bFocusMode = false;
+
+    UPROPERTY(BlueprintReadWrite, Category="Focus")
+    AActor* FocusTarget = nullptr;
+};
+


### PR DESCRIPTION
## Summary
- introduce `CinematicCameraComponent` with support for shoulder switching, camera lag and zoom
- add focus mode following locked target
- integrate optional post-process effects via `PlayerCameraManager`
- expose blueprint events for custom level behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867d53c74648331af1720057d833bed