### PR TITLE
Add basic AI controller and tasks

### DIFF
--- a/Content/ALS_AI/BehaviorTrees/BT_Attack.uasset
+++ b/Content/ALS_AI/BehaviorTrees/BT_Attack.uasset
@@ -1,0 +1,1 @@
+Placeholder BehaviorTree

--- a/Content/ALS_AI/BehaviorTrees/BT_Chase.uasset
+++ b/Content/ALS_AI/BehaviorTrees/BT_Chase.uasset
@@ -1,0 +1,1 @@
+Placeholder BehaviorTree

--- a/Content/ALS_AI/BehaviorTrees/BT_Patrol.uasset
+++ b/Content/ALS_AI/BehaviorTrees/BT_Patrol.uasset
@@ -1,0 +1,1 @@
+Placeholder BehaviorTree

--- a/Content/ALS_AI/EQS/EQS_Attack.uasset
+++ b/Content/ALS_AI/EQS/EQS_Attack.uasset
@@ -1,0 +1,1 @@
+Placeholder EQS

--- a/Content/ALS_AI/EQS/EQS_Chase.uasset
+++ b/Content/ALS_AI/EQS/EQS_Chase.uasset
@@ -1,0 +1,1 @@
+Placeholder EQS

--- a/Content/ALS_AI/EQS/EQS_Patrol.uasset
+++ b/Content/ALS_AI/EQS/EQS_Patrol.uasset
@@ -1,0 +1,1 @@
+Placeholder EQS

--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -31,7 +31,7 @@ public class ALSReplicated : ModuleRules
 			);
 			
 		
-		PrivateDependencyModuleNames.AddRange(
+                PrivateDependencyModuleNames.AddRange(
                         new string[]
                         {
                                 "Core",
@@ -40,6 +40,9 @@ public class ALSReplicated : ModuleRules
                                 "Slate",
                                 "SlateCore",
                                 "UMG",
+                                "AIModule",
+                                "GameplayTasks",
+                                "NavigationSystem",
                                 // ... add private dependencies that you statically link with here ...
                         }
                         );

--- a/Source/ALSReplicated/Private/AI/AAAController.cpp
+++ b/Source/ALSReplicated/Private/AI/AAAController.cpp
@@ -1,0 +1,49 @@
+#include "AI/AAAController.h"
+#include "Perception/AIPerceptionComponent.h"
+#include "Perception/AISenseConfig_Sight.h"
+#include "Perception/AISenseConfig_Hearing.h"
+#include "Net/UnrealNetwork.h"
+
+AALSBaseAIController::AALSBaseAIController()
+{
+    bReplicates = true;
+
+    PerceptionComponent = CreateDefaultSubobject<UAIPerceptionComponent>(TEXT("PerceptionComponent"));
+    SightConfig = CreateDefaultSubobject<UAISenseConfig_Sight>(TEXT("SightConfig"));
+    HearingConfig = CreateDefaultSubobject<UAISenseConfig_Hearing>(TEXT("HearingConfig"));
+
+    if (PerceptionComponent)
+    {
+        PerceptionComponent->SetIsReplicated(true);
+        PerceptionComponent->ConfigureSense(*SightConfig);
+        PerceptionComponent->ConfigureSense(*HearingConfig);
+        PerceptionComponent->SetDominantSense(SightConfig->GetSenseImplementation());
+        PerceptionComponent->OnTargetPerceptionUpdated.AddDynamic(this, &AALSBaseAIController::OnTargetPerceptionUpdated);
+    }
+}
+
+void AALSBaseAIController::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(AALSBaseAIController, CurrentTarget);
+}
+
+void AALSBaseAIController::OnTargetPerceptionUpdated(AActor* Actor, FAIStimulus Stimulus)
+{
+    if (Stimulus.WasSuccessfullySensed())
+    {
+        CurrentTarget = Actor;
+        OnRep_CurrentTarget();
+    }
+    else if (Actor == CurrentTarget)
+    {
+        CurrentTarget = nullptr;
+        OnRep_CurrentTarget();
+    }
+}
+
+void AALSBaseAIController::OnRep_CurrentTarget()
+{
+    // Hook for blueprint or native code
+}
+

--- a/Source/ALSReplicated/Private/AI/Tasks/BTTask_CallBackup.cpp
+++ b/Source/ALSReplicated/Private/AI/Tasks/BTTask_CallBackup.cpp
@@ -1,0 +1,25 @@
+#include "AI/Tasks/BTTask_CallBackup.h"
+#include "GameFramework/Actor.h"
+#include "AIController.h"
+
+UBTTask_CallBackup::UBTTask_CallBackup()
+{
+    NodeName = TEXT("Call Backup");
+}
+
+EBTNodeResult::Type UBTTask_CallBackup::ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
+{
+    AAIController* Controller = OwnerComp.GetAIOwner();
+    if (!Controller)
+    {
+        return EBTNodeResult::Failed;
+    }
+
+    if (AActor* OwnerActor = Controller->GetPawn())
+    {
+        UE_LOG(LogTemp, Warning, TEXT("%s is calling for backup!"), *OwnerActor->GetName());
+    }
+
+    return EBTNodeResult::Succeeded;
+}
+

--- a/Source/ALSReplicated/Private/AI/Tasks/BTTask_CirclePlayer.cpp
+++ b/Source/ALSReplicated/Private/AI/Tasks/BTTask_CirclePlayer.cpp
@@ -1,0 +1,41 @@
+#include "AI/Tasks/BTTask_CirclePlayer.h"
+#include "BehaviorTree/BlackboardComponent.h"
+#include "AIController.h"
+#include "NavigationSystem.h"
+
+UBTTask_CirclePlayer::UBTTask_CirclePlayer()
+{
+    NodeName = TEXT("Circle Player");
+    Radius = 600.f;
+}
+
+EBTNodeResult::Type UBTTask_CirclePlayer::ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
+{
+    AAIController* Controller = OwnerComp.GetAIOwner();
+    if (!Controller)
+    {
+        return EBTNodeResult::Failed;
+    }
+
+    APawn* Pawn = Controller->GetPawn();
+    UObject* TargetObj = OwnerComp.GetBlackboardComponent()->GetValueAsObject(TargetKey.SelectedKeyName);
+    AActor* TargetActor = Cast<AActor>(TargetObj);
+    if (!Pawn || !TargetActor)
+    {
+        return EBTNodeResult::Failed;
+    }
+
+    FVector Direction = (Pawn->GetActorLocation() - TargetActor->GetActorLocation()).GetSafeNormal();
+    FVector CircleLocation = TargetActor->GetActorLocation() + Direction.RotateAngleAxis(90.f, FVector::UpVector) * Radius;
+
+    FNavLocation Result;
+    UNavigationSystemV1* NavSys = UNavigationSystemV1::GetCurrent(Pawn->GetWorld());
+    if (NavSys && NavSys->ProjectPointToNavigation(CircleLocation, Result))
+    {
+        OwnerComp.GetBlackboardComponent()->SetValueAsVector(DestinationKey.SelectedKeyName, Result.Location);
+        return EBTNodeResult::Succeeded;
+    }
+
+    return EBTNodeResult::Failed;
+}
+

--- a/Source/ALSReplicated/Private/AI/Tasks/BTTask_FindCover.cpp
+++ b/Source/ALSReplicated/Private/AI/Tasks/BTTask_FindCover.cpp
@@ -1,0 +1,36 @@
+#include "AI/Tasks/BTTask_FindCover.h"
+#include "AIController.h"
+#include "NavigationSystem.h"
+#include "BehaviorTree/BlackboardComponent.h"
+
+UBTTask_FindCover::UBTTask_FindCover()
+{
+    NodeName = TEXT("Find Cover");
+    SearchRadius = 1000.f;
+}
+
+EBTNodeResult::Type UBTTask_FindCover::ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
+{
+    AAIController* Controller = OwnerComp.GetAIOwner();
+    if (!Controller)
+    {
+        return EBTNodeResult::Failed;
+    }
+
+    APawn* Pawn = Controller->GetPawn();
+    if (!Pawn)
+    {
+        return EBTNodeResult::Failed;
+    }
+
+    FNavLocation Result;
+    UNavigationSystemV1* NavSys = UNavigationSystemV1::GetCurrent(Pawn->GetWorld());
+    if (NavSys && NavSys->GetRandomReachablePointInRadius(Pawn->GetActorLocation(), SearchRadius, Result))
+    {
+        OwnerComp.GetBlackboardComponent()->SetValueAsVector(LocationKey.SelectedKeyName, Result.Location);
+        return EBTNodeResult::Succeeded;
+    }
+
+    return EBTNodeResult::Failed;
+}
+

--- a/Source/ALSReplicated/Public/AI/AAAController.h
+++ b/Source/ALSReplicated/Public/AI/AAAController.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AIController.h"
+#include "Perception/AIPerceptionTypes.h"
+#include "AAAController.generated.h"
+
+class UAIPerceptionComponent;
+class UAISenseConfig_Sight;
+class UAISenseConfig_Hearing;
+
+/**
+ * Basic AI controller used for replicated AI characters.
+ */
+UCLASS()
+class ALSREPLICATED_API AALSBaseAIController : public AAIController
+{
+    GENERATED_BODY()
+
+public:
+    AALSBaseAIController();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+protected:
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="AI")
+    UAIPerceptionComponent* PerceptionComponent;
+
+    UPROPERTY()
+    UAISenseConfig_Sight* SightConfig;
+
+    UPROPERTY()
+    UAISenseConfig_Hearing* HearingConfig;
+
+    UFUNCTION()
+    void OnTargetPerceptionUpdated(AActor* Actor, FAIStimulus Stimulus);
+
+    UPROPERTY(ReplicatedUsing=OnRep_CurrentTarget)
+    AActor* CurrentTarget;
+
+    UFUNCTION()
+    void OnRep_CurrentTarget();
+};
+

--- a/Source/ALSReplicated/Public/AI/Tasks/BTTask_CallBackup.h
+++ b/Source/ALSReplicated/Public/AI/Tasks/BTTask_CallBackup.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BehaviorTree/BTTaskNode.h"
+#include "BTTask_CallBackup.generated.h"
+
+/** Task that triggers an event for backup. */
+UCLASS()
+class ALSREPLICATED_API UBTTask_CallBackup : public UBTTaskNode
+{
+    GENERATED_BODY()
+
+public:
+    UBTTask_CallBackup();
+
+    virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
+};
+

--- a/Source/ALSReplicated/Public/AI/Tasks/BTTask_CirclePlayer.h
+++ b/Source/ALSReplicated/Public/AI/Tasks/BTTask_CirclePlayer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BehaviorTree/BTTaskNode.h"
+#include "BTTask_CirclePlayer.generated.h"
+
+/** Moves the AI pawn to a point around the current target */
+UCLASS()
+class ALSREPLICATED_API UBTTask_CirclePlayer : public UBTTaskNode
+{
+    GENERATED_BODY()
+
+public:
+    UBTTask_CirclePlayer();
+
+    virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
+
+    UPROPERTY(EditAnywhere, Category="Circle")
+    float Radius;
+
+    UPROPERTY(EditAnywhere, Category="Blackboard")
+    FBlackboardKeySelector TargetKey;
+
+    UPROPERTY(EditAnywhere, Category="Blackboard")
+    FBlackboardKeySelector DestinationKey;
+};
+

--- a/Source/ALSReplicated/Public/AI/Tasks/BTTask_FindCover.h
+++ b/Source/ALSReplicated/Public/AI/Tasks/BTTask_FindCover.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BehaviorTree/BTTaskNode.h"
+#include "BTTask_FindCover.generated.h"
+
+/** Simple task that finds a random reachable location around the controlled pawn. */
+UCLASS()
+class ALSREPLICATED_API UBTTask_FindCover : public UBTTaskNode
+{
+    GENERATED_BODY()
+
+public:
+    UBTTask_FindCover();
+
+    virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
+
+    /** Radius to search for cover */
+    UPROPERTY(EditAnywhere, Category="Search")
+    float SearchRadius;
+
+    /** Blackboard key to store the location */
+    UPROPERTY(EditAnywhere, Category="Blackboard")
+    FBlackboardKeySelector LocationKey;
+};
+


### PR DESCRIPTION
## Summary
- implement `AALSBaseAIController` with replicated perception
- add helper BT tasks: FindCover, CirclePlayer, CallBackup
- stub behaviour tree and EQS assets for AI
- include AIModule dependencies

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867d6cdc83483319979e6dc5e3530b6