### PR TITLE
Fix naming typos in movement component

### DIFF
--- a/Source/ALSReplicated/Private/ALSCharacterMovementComponent.cpp
+++ b/Source/ALSReplicated/Private/ALSCharacterMovementComponent.cpp
@@ -7,11 +7,11 @@ void UALSCharacterMovementComponent::GetLifetimeReplicatedProps(TArray<FLifetime
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewMaxWalkSpeed, COND_SkipOwner);
-	DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewMaxWalkSpeedCrounched, COND_SkipOwner);
+        DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewMaxWalkSpeedCrouched, COND_SkipOwner);
 	DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewMaxAcceleration, COND_SkipOwner);
 	DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewBrakingDecelerationWalking, COND_SkipOwner);
 	DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewGroundFriction, COND_SkipOwner);
-	DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewBrakingFricktionFactor, COND_SkipOwner);
+        DOREPLIFETIME_CONDITION(UALSCharacterMovementComponent, NewBrakingFrictionFactor, COND_SkipOwner);
 }
 
 void UALSCharacterMovementComponent::SetMaxWalkSpeed(float Max_WalkSpeed)
@@ -21,11 +21,11 @@ void UALSCharacterMovementComponent::SetMaxWalkSpeed(float Max_WalkSpeed)
 	MaxWalkSpeed = NewMaxWalkSpeed;
 }
 
-void UALSCharacterMovementComponent::SetMaxWalkSpeedCrounched(float Max_WalkSpeedCrounched)
+void UALSCharacterMovementComponent::SetMaxWalkSpeedCrouched(float Max_WalkSpeedCrouched)
 {
-	NewMaxWalkSpeedCrounched = Max_WalkSpeedCrounched;
-	Server_MaxWalkSpeedCrounched_Implementation(NewMaxWalkSpeedCrounched);
-	MaxWalkSpeedCrouched = NewMaxWalkSpeedCrounched;
+        NewMaxWalkSpeedCrouched = Max_WalkSpeedCrouched;
+        Server_MaxWalkSpeedCrouched_Implementation(NewMaxWalkSpeedCrouched);
+        MaxWalkSpeedCrouched = NewMaxWalkSpeedCrouched;
 }
 
 void UALSCharacterMovementComponent::SetMaxAcceleration(float Max_Acceleration)
@@ -49,11 +49,11 @@ void UALSCharacterMovementComponent::SetGroundFriction(float Ground_Friction)
 	GroundFriction = NewGroundFriction;
 }
 
-void UALSCharacterMovementComponent::SetBrakingFricktionFactor(float Braking_FricktionFactor)
+void UALSCharacterMovementComponent::SetBrakingFrictionFactor(float Braking_FrictionFactor)
 {
-	NewBrakingFricktionFactor = Braking_FricktionFactor;
-	Server_BrakingFricktionFactor_Implementation(NewBrakingFricktionFactor);
-	BrakingFrictionFactor = NewBrakingFricktionFactor;
+        NewBrakingFrictionFactor = Braking_FrictionFactor;
+        Server_BrakingFrictionFactor_Implementation(NewBrakingFrictionFactor);
+        BrakingFrictionFactor = NewBrakingFrictionFactor;
 }
 
 void UALSCharacterMovementComponent::Server_MaxWalkSpeed_Implementation(float Max_WalkSpeed)
@@ -61,9 +61,9 @@ void UALSCharacterMovementComponent::Server_MaxWalkSpeed_Implementation(float Ma
 	NewMaxWalkSpeed = Max_WalkSpeed;
 }
 
-void UALSCharacterMovementComponent::Server_MaxWalkSpeedCrounched_Implementation(float Max_WalkSpeedCrounched)
+void UALSCharacterMovementComponent::Server_MaxWalkSpeedCrouched_Implementation(float Max_WalkSpeedCrouched)
 {
-	MaxWalkSpeedCrouched = Max_WalkSpeedCrounched;
+        MaxWalkSpeedCrouched = Max_WalkSpeedCrouched;
 }
 
 void UALSCharacterMovementComponent::Server_MaxAcceleration_Implementation(float Max_Acceleration)
@@ -81,7 +81,7 @@ void UALSCharacterMovementComponent::Server_GroundFriction_Implementation(float 
 	NewGroundFriction = Ground_Friction;
 }
 
-void UALSCharacterMovementComponent::Server_BrakingFricktionFactor_Implementation(float Braking_FricktionFactor)
+void UALSCharacterMovementComponent::Server_BrakingFrictionFactor_Implementation(float Braking_FrictionFactor)
 {
-	NewBrakingFricktionFactor = Braking_FricktionFactor;
+        NewBrakingFrictionFactor = Braking_FrictionFactor;
 }

--- a/Source/ALSReplicated/Public/ALSCharacterMovementComponent.h
+++ b/Source/ALSReplicated/Public/ALSCharacterMovementComponent.h
@@ -21,8 +21,8 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Movement Component")
 	void SetMaxWalkSpeed(float Max_WalkSpeed);
 
-	UFUNCTION(BlueprintCallable, Category="Movement Component")
-	void SetMaxWalkSpeedCrounched(float Max_WalkSpeedCrounched);
+        UFUNCTION(BlueprintCallable, Category="Movement Component")
+        void SetMaxWalkSpeedCrouched(float Max_WalkSpeedCrouched);
 
 	UFUNCTION(BlueprintCallable, Category="Movement Component")
 	void SetMaxAcceleration(float Max_Acceleration);
@@ -33,15 +33,15 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Movement Component")
 	void SetGroundFriction(float Ground_Friction);
 
-	UFUNCTION(BlueprintCallable, Category="Movement Component")
-	void SetBrakingFricktionFactor(float Braking_FricktionFactor);
+        UFUNCTION(BlueprintCallable, Category="Movement Component")
+        void SetBrakingFrictionFactor(float Braking_FrictionFactor);
 	
 private:
 	UPROPERTY(Replicated)
 	float NewMaxWalkSpeed = MaxWalkSpeed;
 	
 	UPROPERTY(Replicated)
-	float NewMaxWalkSpeedCrounched = MaxWalkSpeedCrouched;
+        float NewMaxWalkSpeedCrouched = MaxWalkSpeedCrouched;
 
 	UPROPERTY(Replicated)
 	float NewMaxAcceleration = MaxAcceleration;
@@ -53,13 +53,13 @@ private:
     float NewGroundFriction = GroundFriction;
 
 	UPROPERTY(Replicated)
-	float NewBrakingFricktionFactor = BrakingFrictionFactor;
+        float NewBrakingFrictionFactor = BrakingFrictionFactor;
 
 	UFUNCTION(Server, Reliable)
 	void Server_MaxWalkSpeed(float Max_WalkSpeed);
 
 	UFUNCTION(Server, Reliable)
-	void Server_MaxWalkSpeedCrounched(float Max_WalkSpeedCrounched);
+        void Server_MaxWalkSpeedCrouched(float Max_WalkSpeedCrouched);
 
 	UFUNCTION(Server, Reliable)
 	void Server_MaxAcceleration(float Max_Acceleration);
@@ -71,7 +71,7 @@ private:
 	void Server_GroundFriction(float Ground_Friction);
 
 	UFUNCTION(Server, Reliable)
-	void Server_BrakingFricktionFactor(float Braking_FricktionFactor);
+        void Server_BrakingFrictionFactor(float Braking_FrictionFactor);
 	
 };
 


### PR DESCRIPTION
## Summary
- rename `SetMaxWalkSpeedCrounched` to `SetMaxWalkSpeedCrouched`
- rename `SetBrakingFricktionFactor` to `SetBrakingFrictionFactor`
- update replicated variable names and server RPCs accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685b3a74788331a2288dbc25307bc0