### PR TITLE
Initialize control rotation in BeginPlay

### DIFF
--- a/Source/ALSReplicated/Private/ALSBaseCharacter.cpp
+++ b/Source/ALSReplicated/Private/ALSBaseCharacter.cpp
@@ -22,7 +22,9 @@ AALSBaseCharacter::AALSBaseCharacter(const FObjectInitializer& ObjectInitializer
 // Called when the game starts or when spawned
 void AALSBaseCharacter::BeginPlay()
 {
-	Super::BeginPlay();
+        Super::BeginPlay();
+
+       ControlRotation = GetControlRotation();
 
 	ALSCharacterMovement = Cast<UALSCharacterMovementComponent>(GetCharacterMovement());
 

--- a/Source/ALSReplicated/Public/ALSBaseCharacter.h
+++ b/Source/ALSReplicated/Public/ALSBaseCharacter.h
@@ -47,8 +47,8 @@ public:
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
-	UPROPERTY(BlueprintReadWrite, Replicated, Category="ALS || Rotation")
-	FRotator ControlRotation = GetControlRotation();
+       UPROPERTY(BlueprintReadWrite, Replicated, Category="ALS || Rotation")
+       FRotator ControlRotation = FRotator::ZeroRotator;
 
         UPROPERTY(BlueprintReadWrite, Category="ALS || Component")
         UALSCharacterMovementComponent* ALSCharacterMovement;


### PR DESCRIPTION
## Summary
- set `ControlRotation` default to `ZeroRotator`
- capture the controller's rotation during `BeginPlay`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ba6866cc8331aec0ed9d1b92283f