### PR TITLE
Add attack state blueprint event

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,8 @@ A description of what actually happens.
   +DefaultChannelResponses=(Channel=ECC_GameTraceChannel2,DefaultResponse=ECR_Block,bTraceType=True,bStaticObject=False,Name="Climbable")
   ```
 
+## Blueprint Events
+
+`UCombatComponent` exposes the `OnAttackStateChanged` event which is triggered whenever an attack begins or ends. Implement this in your blueprint to play effects or update the UI when `bAttacking` is `true` or `false`.
+
 @

--- a/Source/ALSReplicated/Private/CombatComponent.cpp
+++ b/Source/ALSReplicated/Private/CombatComponent.cpp
@@ -118,7 +118,7 @@ void UCombatComponent::ResetCombo()
 
 void UCombatComponent::OnRep_AttackState()
 {
-    // This function can be extended to react to attack state changes
+    OnAttackStateChanged(bIsAttacking);
 }
 
 void UCombatComponent::EquipWeapon(AActor* Weapon, FName SocketName)

--- a/Source/ALSReplicated/Public/CombatComponent.h
+++ b/Source/ALSReplicated/Public/CombatComponent.h
@@ -44,6 +44,14 @@ public:
     UFUNCTION(BlueprintImplementableEvent, Category="Combat")
     void OnHitDetected(const FHitResult& Hit);
 
+    /**
+     * Called whenever the attack state changes.
+     * Implement in Blueprint to play VFX, sounds or UI feedback
+     * when an attack starts (bAttacking = true) or ends.
+     */
+    UFUNCTION(BlueprintImplementableEvent, Category="Combat")
+    void OnAttackStateChanged(bool bAttacking);
+
 protected:
     virtual void BeginPlay() override;
 


### PR DESCRIPTION
## Summary
- expose `OnAttackStateChanged` event in CombatComponent
- trigger `OnAttackStateChanged` when attack state replicates
- document the new event in README for blueprint usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869081fe6b0833194405a336e803ed9