### PR TITLE
Improve lock-on tick control

### DIFF
--- a/Source/ALSReplicated/Private/LockOnComponent.cpp
+++ b/Source/ALSReplicated/Private/LockOnComponent.cpp
@@ -9,7 +9,8 @@
 
 ULockOnComponent::ULockOnComponent()
 {
-    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.bCanEverTick = false;
+    SetComponentTickEnabled(false);
     SetIsReplicatedByDefault(true);
 }
 
@@ -18,6 +19,7 @@ void ULockOnComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& Out
     Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
     DOREPLIFETIME(ULockOnComponent, LockedTargetId);
+    DOREPLIFETIME(ULockOnComponent, bTickActive);
 }
 
 void ULockOnComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
@@ -50,6 +52,8 @@ void ULockOnComponent::DoToggleLockOn()
 {
     if (CurrentTarget)
     {
+        bTickActive = false;
+        SetComponentTickEnabled(false);
         CurrentTarget = nullptr;
         LockedTargetId = FNetworkGUID();
         HideReticle();
@@ -59,6 +63,8 @@ void ULockOnComponent::DoToggleLockOn()
     APawn* NewTarget = FindNearestTarget();
     if (NewTarget)
     {
+        bTickActive = true;
+        SetComponentTickEnabled(true);
         CurrentTarget = NewTarget;
 
         if (UNetDriver* Driver = GetWorld()->GetNetDriver())
@@ -156,5 +162,12 @@ void ULockOnComponent::OnRep_LockedTarget()
     {
         HideReticle();
     }
+
+    SetComponentTickEnabled(bTickActive);
+}
+
+void ULockOnComponent::OnRep_TickActive()
+{
+    SetComponentTickEnabled(bTickActive);
 }
 

--- a/Source/ALSReplicated/Public/LockOnComponent.h
+++ b/Source/ALSReplicated/Public/LockOnComponent.h
@@ -44,11 +44,17 @@ protected:
        UFUNCTION()
        void OnRep_LockedTarget();
 
+       UFUNCTION()
+       void OnRep_TickActive();
+
        UPROPERTY(ReplicatedUsing=OnRep_LockedTarget)
        FNetworkGUID LockedTargetId;
 
        UPROPERTY(Transient)
        APawn* CurrentTarget = nullptr;
+
+       UPROPERTY(ReplicatedUsing=OnRep_TickActive)
+       bool bTickActive = false;
 
        UPROPERTY(EditDefaultsOnly, Category="LockOn")
        float TraceRange = 2000.0f;


### PR DESCRIPTION
## Summary
- start LockOnComponent with ticking disabled
- sync tick state across the network
- enable and disable ticking as the lock-on state changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68690a0f9b3c8331a2093ab81afa7aa4