### PR TITLE
Add multicast replication for environment interactions

### DIFF
--- a/Source/ALSReplicated/Private/EnvironmentInteractionComponent.cpp
+++ b/Source/ALSReplicated/Private/EnvironmentInteractionComponent.cpp
@@ -191,6 +191,7 @@ void UEnvironmentInteractionComponent::ServerInteract_Implementation(AActor* Tar
     LastAction = Action;
 
     HandleInteraction(Target, Action);
+    MulticastInteract(Target, Action);
 }
 
 void UEnvironmentInteractionComponent::HandleInteraction(AActor* Target, const FString& Action)
@@ -199,6 +200,9 @@ void UEnvironmentInteractionComponent::HandleInteraction(AActor* Target, const F
     {
         return;
     }
+
+    Target->SetReplicates(true);
+    Target->SetReplicateMovement(true);
 
     if (Action == TEXT("Push"))
     {
@@ -223,6 +227,14 @@ void UEnvironmentInteractionComponent::HandleInteraction(AActor* Target, const F
     else if (Action == TEXT("UseZipline"))
     {
         // Placeholder: actual zipline logic should handle movement
+    }
+}
+
+void UEnvironmentInteractionComponent::MulticastInteract_Implementation(AActor* Target, const FString& Action)
+{
+    if (GetOwnerRole() == ROLE_SimulatedProxy)
+    {
+        HandleInteraction(Target, Action);
     }
 }
 

--- a/Source/ALSReplicated/Public/EnvironmentInteractionComponent.h
+++ b/Source/ALSReplicated/Public/EnvironmentInteractionComponent.h
@@ -48,6 +48,9 @@ protected:
     UFUNCTION(Server, Reliable)
     void ServerBeginInteraction(const FString& Action, float Duration);
 
+    UFUNCTION(NetMulticast, Reliable)
+    void MulticastInteract(AActor* Target, const FString& Action);
+
     UFUNCTION()
     void OnRep_Interaction();
 


### PR DESCRIPTION
## Summary
- add multicast function to propagate interaction actions
- enable replication of interacted actors and their movement
- call multicast after server processes an interaction

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68690c2475148331a4e8f0e46ea85588