### PR TITLE
Add server RPCs for weapon equip

### DIFF
--- a/Source/ALSReplicated/Private/CombatComponent.cpp
+++ b/Source/ALSReplicated/Private/CombatComponent.cpp
@@ -128,6 +128,12 @@ void UCombatComponent::EquipWeapon(AActor* Weapon, FName SocketName)
         return;
     }
 
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerEquipWeapon(Weapon, SocketName);
+        return;
+    }
+
     if (ACharacter* OwnerCharacter = Cast<ACharacter>(GetOwner()))
     {
         Weapon->AttachToComponent(OwnerCharacter->GetMesh(), FAttachmentTransformRules::SnapToTargetNotIncludingScale, SocketName);
@@ -138,11 +144,27 @@ void UCombatComponent::EquipWeapon(AActor* Weapon, FName SocketName)
 
 void UCombatComponent::UnequipWeapon()
 {
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerUnequipWeapon();
+        return;
+    }
+
     if (EquippedWeapon)
     {
         EquippedWeapon->DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
         EquippedWeapon = nullptr;
     }
+}
+
+void UCombatComponent::ServerEquipWeapon_Implementation(AActor* Weapon, FName SocketName)
+{
+    EquipWeapon(Weapon, SocketName);
+}
+
+void UCombatComponent::ServerUnequipWeapon_Implementation()
+{
+    UnequipWeapon();
 }
 
 void UCombatComponent::SpawnHitbox()

--- a/Source/ALSReplicated/Public/CombatComponent.h
+++ b/Source/ALSReplicated/Public/CombatComponent.h
@@ -54,6 +54,12 @@ protected:
     UFUNCTION(Server, Reliable)
     void ServerStartAttack(bool bHeavy);
 
+    UFUNCTION(Server, Reliable)
+    void ServerEquipWeapon(AActor* Weapon, FName SocketName);
+
+    UFUNCTION(Server, Reliable)
+    void ServerUnequipWeapon();
+
     void DoAttack(bool bHeavy);
     void FinishAttack();
     void ResetCombo();


### PR DESCRIPTION
## Summary
- add `ServerEquipWeapon` and `ServerUnequipWeapon` RPCs in `UCombatComponent`
- call RPCs from `EquipWeapon` and `UnequipWeapon` when client controlled
- server performs attachment so replication reaches all clients

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68691132c2ac8331aab13b8c738cd902