### PR TITLE
Improve camera post process handling

### DIFF
--- a/Source/ALSReplicated/Private/Camera/AdvancedCameraComponent.cpp
+++ b/Source/ALSReplicated/Private/Camera/AdvancedCameraComponent.cpp
@@ -54,13 +54,34 @@ void UAdvancedCameraComponent::TickComponent(float DeltaTime, ELevelTick TickTyp
         }
     }
 
-    if (bUsePostProcess)
+    UpdatePostProcess();
+}
+
+void UAdvancedCameraComponent::UpdatePostProcess()
+{
+    if (!bUsePostProcess)
     {
-        if (APlayerController* PC = OwnerPawn ? Cast<APlayerController>(OwnerPawn->GetController()) : nullptr)
+        bPostProcessApplied = false;
+        return;
+    }
+
+    bool bSettingsChanged = !PostProcessSettings.Equals(CachedPostProcessSettings);
+    bool bWeightChanged = !FMath::IsNearlyEqual(PostProcessBlendWeight, CachedBlendWeight);
+
+    if (!bPostProcessApplied || bSettingsChanged || bWeightChanged)
+    {
+        APawn* OwnerPawn = Cast<APawn>(GetOwner());
+        if (OwnerPawn)
         {
-            if (APlayerCameraManager* PCM = PC->PlayerCameraManager)
+            if (APlayerController* PC = Cast<APlayerController>(OwnerPawn->GetController()))
             {
-                PCM->AddCachedPPBlend(PostProcessSettings, PostProcessBlendWeight);
+                if (APlayerCameraManager* PCM = PC->PlayerCameraManager)
+                {
+                    PCM->AddCachedPPBlend(PostProcessSettings, PostProcessBlendWeight);
+                    CachedPostProcessSettings = PostProcessSettings;
+                    CachedBlendWeight = PostProcessBlendWeight;
+                    bPostProcessApplied = true;
+                }
             }
         }
     }

--- a/Source/ALSReplicated/Private/Camera/CinematicCameraComponent.cpp
+++ b/Source/ALSReplicated/Private/Camera/CinematicCameraComponent.cpp
@@ -65,7 +65,21 @@ void UCinematicCameraComponent::TickComponent(float DeltaTime, ELevelTick TickTy
         SetWorldRotation(FMath::RInterpTo(GetComponentRotation(), DesiredRot, DeltaTime, LagSpeed));
     }
 
-    if (bUsePostProcess)
+    UpdatePostProcess();
+}
+
+void UCinematicCameraComponent::UpdatePostProcess()
+{
+    if (!bUsePostProcess)
+    {
+        bPostProcessApplied = false;
+        return;
+    }
+
+    bool bSettingsChanged = !PostProcessSettings.Equals(CachedPostProcessSettings);
+    bool bWeightChanged = !FMath::IsNearlyEqual(PostProcessBlendWeight, CachedBlendWeight);
+
+    if (!bPostProcessApplied || bSettingsChanged || bWeightChanged)
     {
         if (AActor* OwnerActor = GetOwner())
         {
@@ -74,6 +88,9 @@ void UCinematicCameraComponent::TickComponent(float DeltaTime, ELevelTick TickTy
                 if (APlayerCameraManager* PCM = PC->PlayerCameraManager)
                 {
                     PCM->AddCachedPPBlend(PostProcessSettings, PostProcessBlendWeight);
+                    CachedPostProcessSettings = PostProcessSettings;
+                    CachedBlendWeight = PostProcessBlendWeight;
+                    bPostProcessApplied = true;
                 }
             }
         }

--- a/Source/ALSReplicated/Public/Camera/AdvancedCameraComponent.h
+++ b/Source/ALSReplicated/Public/Camera/AdvancedCameraComponent.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/SpringArmComponent.h"
+#include "Engine/Scene.h"
 #include "LockOnComponent.h"
 #include "AdvancedCameraComponent.generated.h"
 
@@ -56,5 +57,13 @@ protected:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess", meta=(EditCondition="bUsePostProcess"))
     float PostProcessBlendWeight = 1.f;
+
+    /** Update the cached post process blend when settings change */
+    UFUNCTION(BlueprintCallable, Category="PostProcess")
+    void UpdatePostProcess();
+
+    bool bPostProcessApplied = false;
+    FPostProcessSettings CachedPostProcessSettings;
+    float CachedBlendWeight = 0.f;
 };
 

--- a/Source/ALSReplicated/Public/CinematicCameraComponent.h
+++ b/Source/ALSReplicated/Public/CinematicCameraComponent.h
@@ -71,6 +71,14 @@ protected:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess", meta=(EditCondition="bUsePostProcess"))
     float PostProcessBlendWeight = 1.f;
 
+    /** Update the cached post process blend when settings change */
+    UFUNCTION(BlueprintCallable, Category="PostProcess")
+    void UpdatePostProcess();
+
+    bool bPostProcessApplied = false;
+    FPostProcessSettings CachedPostProcessSettings;
+    float CachedBlendWeight = 0.f;
+
     UPROPERTY(BlueprintReadWrite, Category="Focus")
     bool bFocusMode = false;
 


### PR DESCRIPTION
## Summary
- add cached state for post process settings on both camera components
- update post process only when settings or blend weight change
- expose `UpdatePostProcess` to Blueprints

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686992d74bd88331899cf25913f42def