### PR TITLE
Add additional replication tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ A description of what actually happens.
 
 ## Automation Tests
 
-A set of automation tests validates component replication. Open **Session Frontend** in the Unreal Editor and run the tests under `ALSReplicated.ComponentReplication`. Alternatively, run them from the command line:
+A set of automation tests validates component replication. Open **Session Frontend** in the Unreal Editor and run the tests under `ALSReplicated.ComponentReplication`, `ALSReplicated.StaminaReplication`, `ALSReplicated.LockOn.TargetReplication` and `ALSReplicated.EnvironmentInteractionReplication`. Alternatively, run them from the command line:
 
 ```
-UE4Editor.exe <YourProject>.uproject -run=Automation -test=ALSReplicated.ComponentReplication -unattended
+UE4Editor.exe <YourProject>.uproject -run=Automation -test=ALSReplicated.* -unattended
 ```
 
 ## Interactive Actor Setup

--- a/Source/ALSReplicated/Private/Tests/AdditionalReplicationTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/AdditionalReplicationTests.cpp
@@ -1,0 +1,45 @@
+#include "Misc/AutomationTest.h"
+#include "CombatComponent.h"
+#include "LockOnComponent.h"
+#include "EnvironmentInteractionComponent.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FStaminaReplicationTest, "ALSReplicated.StaminaReplication", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FStaminaReplicationTest::RunTest(const FString& Parameters)
+{
+    UClass* CombatClass = UCombatComponent::StaticClass();
+    FProperty* Prop = CombatClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UCombatComponent, Stamina));
+    const bool bReplicated = Prop && Prop->HasAnyPropertyFlags(CPF_Net);
+    TestTrue(TEXT("Stamina should replicate"), bReplicated);
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FLockOnTargetReplicationTest, "ALSReplicated.LockOn.TargetReplication", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FLockOnTargetReplicationTest::RunTest(const FString& Parameters)
+{
+    UClass* LockOnClass = ULockOnComponent::StaticClass();
+    FProperty* Prop = LockOnClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(ULockOnComponent, LockedTargetId));
+    const bool bReplicated = Prop && Prop->HasAnyPropertyFlags(CPF_Net);
+    TestTrue(TEXT("LockedTargetId should replicate"), bReplicated);
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FEnvironmentInteractionReplicationTest, "ALSReplicated.EnvironmentInteractionReplication", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FEnvironmentInteractionReplicationTest::RunTest(const FString& Parameters)
+{
+    UClass* EnvClass = UEnvironmentInteractionComponent::StaticClass();
+
+    FProperty* InteractedProp = EnvClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UEnvironmentInteractionComponent, InteractedActor));
+    TestTrue(TEXT("InteractedActor should replicate"), InteractedProp && InteractedProp->HasAnyPropertyFlags(CPF_Net));
+
+    FProperty* ActionProp = EnvClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UEnvironmentInteractionComponent, LastAction));
+    TestTrue(TEXT("LastAction should replicate"), ActionProp && ActionProp->HasAnyPropertyFlags(CPF_Net));
+
+    FProperty* InteractingProp = EnvClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UEnvironmentInteractionComponent, bIsInteracting));
+    TestTrue(TEXT("bIsInteracting should replicate"), InteractingProp && InteractingProp->HasAnyPropertyFlags(CPF_Net));
+
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary
- add new automation tests for stamina, lock-on, and environment interaction replication
- document running the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68699ab990e88331b3eaccc6f6073c29