### PR TITLE
Add OnRep movement updates

### DIFF
--- a/Source/ALSReplicated/Private/ALSCharacterMovementComponent.cpp
+++ b/Source/ALSReplicated/Private/ALSCharacterMovementComponent.cpp
@@ -85,3 +85,33 @@ void UALSCharacterMovementComponent::Server_BrakingFrictionFactor_Implementation
 {
         NewBrakingFrictionFactor = Braking_FrictionFactor;
 }
+
+void UALSCharacterMovementComponent::OnRep_NewMaxWalkSpeed()
+{
+    MaxWalkSpeed = NewMaxWalkSpeed;
+}
+
+void UALSCharacterMovementComponent::OnRep_NewMaxWalkSpeedCrouched()
+{
+    MaxWalkSpeedCrouched = NewMaxWalkSpeedCrouched;
+}
+
+void UALSCharacterMovementComponent::OnRep_NewMaxAcceleration()
+{
+    MaxAcceleration = NewMaxAcceleration;
+}
+
+void UALSCharacterMovementComponent::OnRep_NewBrakingDecelerationWalking()
+{
+    BrakingDecelerationWalking = NewBrakingDecelerationWalking;
+}
+
+void UALSCharacterMovementComponent::OnRep_NewGroundFriction()
+{
+    GroundFriction = NewGroundFriction;
+}
+
+void UALSCharacterMovementComponent::OnRep_NewBrakingFrictionFactor()
+{
+    BrakingFrictionFactor = NewBrakingFrictionFactor;
+}

--- a/Source/ALSReplicated/Public/ALSCharacterMovementComponent.h
+++ b/Source/ALSReplicated/Public/ALSCharacterMovementComponent.h
@@ -37,23 +37,41 @@ public:
         void SetBrakingFrictionFactor(float Braking_FrictionFactor);
 	
 private:
-	UPROPERTY(Replicated)
-	float NewMaxWalkSpeed = MaxWalkSpeed;
-	
-	UPROPERTY(Replicated)
-        float NewMaxWalkSpeedCrouched = MaxWalkSpeedCrouched;
+       UFUNCTION()
+       void OnRep_NewMaxWalkSpeed();
 
-	UPROPERTY(Replicated)
-	float NewMaxAcceleration = MaxAcceleration;
+       UFUNCTION()
+       void OnRep_NewMaxWalkSpeedCrouched();
 
-	UPROPERTY(Replicated)
-	float NewBrakingDecelerationWalking = BrakingDecelerationWalking;
-	
-	UPROPERTY(Replicated)
-    float NewGroundFriction = GroundFriction;
+       UFUNCTION()
+       void OnRep_NewMaxAcceleration();
 
-	UPROPERTY(Replicated)
-        float NewBrakingFrictionFactor = BrakingFrictionFactor;
+       UFUNCTION()
+       void OnRep_NewBrakingDecelerationWalking();
+
+       UFUNCTION()
+       void OnRep_NewGroundFriction();
+
+       UFUNCTION()
+       void OnRep_NewBrakingFrictionFactor();
+
+       UPROPERTY(ReplicatedUsing=OnRep_NewMaxWalkSpeed)
+       float NewMaxWalkSpeed = MaxWalkSpeed;
+
+       UPROPERTY(ReplicatedUsing=OnRep_NewMaxWalkSpeedCrouched)
+       float NewMaxWalkSpeedCrouched = MaxWalkSpeedCrouched;
+
+       UPROPERTY(ReplicatedUsing=OnRep_NewMaxAcceleration)
+       float NewMaxAcceleration = MaxAcceleration;
+
+       UPROPERTY(ReplicatedUsing=OnRep_NewBrakingDecelerationWalking)
+       float NewBrakingDecelerationWalking = BrakingDecelerationWalking;
+
+       UPROPERTY(ReplicatedUsing=OnRep_NewGroundFriction)
+   float NewGroundFriction = GroundFriction;
+
+       UPROPERTY(ReplicatedUsing=OnRep_NewBrakingFrictionFactor)
+       float NewBrakingFrictionFactor = BrakingFrictionFactor;
 
 	UFUNCTION(Server, Reliable)
 	void Server_MaxWalkSpeed(float Max_WalkSpeed);


### PR DESCRIPTION
## Summary
- replicate character movement values with new `OnRep` handlers
- update speed, acceleration, braking and friction when properties replicate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869abe83f088331b37a31aaafc5dafb