### PR TITLE
Add enum-based interaction actions

### DIFF
--- a/Source/ALSReplicated/Public/EnvironmentInteractionComponent.h
+++ b/Source/ALSReplicated/Public/EnvironmentInteractionComponent.h
@@ -10,6 +10,18 @@
 #include "CableComponent.h"
 #include "EnvironmentInteractionComponent.generated.h"
 
+UENUM(BlueprintType)
+enum class EInteractionAction : uint8
+{
+    None,
+    Push,
+    Pull,
+    OpenDoor,
+    UseLever,
+    GrabLedge,
+    UseZipline
+};
+
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class ALSREPLICATED_API UEnvironmentInteractionComponent : public UActorComponent
 {
@@ -45,28 +57,28 @@ public:
 
 protected:
     UFUNCTION(Server, Reliable, WithValidation)
-    void ServerInteract(AActor* Target, const FString& Action);
+    void ServerInteract(AActor* Target, EInteractionAction Action);
 
     UFUNCTION(Server, Reliable, WithValidation)
-    void ServerBeginInteraction(const FString& Action, float Duration);
+    void ServerBeginInteraction(EInteractionAction Action, float Duration);
 
     UFUNCTION(NetMulticast, Reliable)
-    void MulticastInteract(AActor* Target, const FString& Action);
+    void MulticastInteract(AActor* Target, EInteractionAction Action);
 
     UFUNCTION()
     void OnRep_Interaction();
 
     void PerformTrace(FHitResult& Hit);
-    void HandleInteraction(AActor* Target, const FString& Action);
+    void HandleInteraction(AActor* Target, EInteractionAction Action);
 
-    void BeginInteraction(const FString& Action, float Duration = 1.0f);
+    void BeginInteraction(EInteractionAction Action, float Duration = 1.0f);
     void EndInteraction();
 
     UPROPERTY(ReplicatedUsing=OnRep_Interaction)
     AActor* InteractedActor = nullptr;
 
     UPROPERTY(ReplicatedUsing=OnRep_Interaction)
-    FString LastAction;
+    TEnumAsByte<EInteractionAction> LastAction = EInteractionAction::None;
 
     UPROPERTY(EditDefaultsOnly, Category="Interaction")
     FGameplayTag LedgeTag;


### PR DESCRIPTION
## Summary
- define `EInteractionAction` to enumerate interaction types
- replace `FString` parameters with the enum
- replicate `LastAction` using the enum
- adjust interaction handling logic to use a switch on the new enum

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869c02ffd9c8331913b9d672d4bf4ec