### PR TITLE
Guard replication state in HandleInteraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,5 @@ UE4Editor.exe <YourProject>.uproject -run=Automation -test=ALSReplicated.* -unat
 
 Interactive objects that you intend to push, pull or otherwise move should replicate their movement. Ensure the actor has **bReplicateMovement** enabled or that you manually replicate its transform. For the best network prediction during push and pull, use a `UPrimitiveComponent` with physics simulation and call `SetPhysicsLinearVelocity` rather than directly updating the actor transform.
 
+Actors involved in interactions should also enable **bReplicates** and **bReplicateMovement** in their constructors or blueprint defaults. `UEnvironmentInteractionComponent` no longer forces these flags at runtime and will only log a warning if they are missing.
+

--- a/Source/ALSReplicated/Private/EnvironmentInteractionComponent.cpp
+++ b/Source/ALSReplicated/Private/EnvironmentInteractionComponent.cpp
@@ -214,11 +214,14 @@ void UEnvironmentInteractionComponent::HandleInteraction(AActor* Target, EIntera
         return;
     }
 
-    Target->SetReplicates(true);
+    if (!Target->GetIsReplicated())
+    {
+        UE_LOG(LogTemp, Warning, TEXT("Interactive actor %s is not set to replicate."), *Target->GetName());
+    }
+
     if (!Target->GetReplicateMovement())
     {
-        UE_LOG(LogTemp, Warning, TEXT("Interactive actor %s missing bReplicateMovement. Enabling replication."), *Target->GetName());
-        Target->SetReplicateMovement(true);
+        UE_LOG(LogTemp, Warning, TEXT("Interactive actor %s missing bReplicateMovement."), *Target->GetName());
     }
 
     UPrimitiveComponent* RootPrim = Cast<UPrimitiveComponent>(Target->GetRootComponent());


### PR DESCRIPTION
## Summary
- warn if interactive actors aren't replicated
- update interactive actor setup docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869cc1e2e80833194d2badc798a696f