### PR TITLE
Refactor Cinematic camera to use base component

### DIFF
--- a/Source/ALSReplicated/Private/Camera/CinematicCameraComponent.cpp
+++ b/Source/ALSReplicated/Private/Camera/CinematicCameraComponent.cpp
@@ -5,10 +5,8 @@
 #include "GameFramework/Pawn.h"
 
 UCinematicCameraComponent::UCinematicCameraComponent()
+    : Super()
 {
-    PrimaryComponentTick.bCanEverTick = true;
-    TargetArmLength = 300.f;
-    DesiredArmLength = TargetArmLength;
 }
 
 void UCinematicCameraComponent::SwitchShoulder()
@@ -16,11 +14,6 @@ void UCinematicCameraComponent::SwitchShoulder()
     ToggleShoulder();
 }
 
-void UCinematicCameraComponent::SetDesiredArmLength(float Length)
-{
-    DesiredArmLength = Length;
-    OnZoomChanged(Length);
-}
 
 void UCinematicCameraComponent::EnterFocusMode(AActor* Target)
 {
@@ -42,27 +35,6 @@ void UCinematicCameraComponent::ExitFocusMode()
     }
 }
 
-void UCinematicCameraComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
-{
-    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-
-    TargetArmLength = FMath::FInterpTo(TargetArmLength, DesiredArmLength, DeltaTime, ZoomInterpSpeed);
-
-    FVector DesiredOffset(0.f, bRightShoulder ? ShoulderOffset : -ShoulderOffset, 0.f);
-    if (bEnableLag)
-    {
-        SocketOffset = FMath::VInterpTo(SocketOffset, DesiredOffset, DeltaTime, LagSpeed);
-    }
-    else
-    {
-        SocketOffset = DesiredOffset;
-    }
-
-    UpdateOrientation(DeltaTime);
-
-    UpdatePostProcess();
-}
-
 void UCinematicCameraComponent::UpdateOrientation(float DeltaTime)
 {
     if (bFocusMode && FocusTarget)
@@ -72,37 +44,3 @@ void UCinematicCameraComponent::UpdateOrientation(float DeltaTime)
         SetWorldRotation(FMath::RInterpTo(GetComponentRotation(), DesiredRot, DeltaTime, LagSpeed));
     }
 }
-
-void UCinematicCameraComponent::UpdatePostProcess()
-{
-    if (!bUsePostProcess)
-    {
-        bPostProcessApplied = false;
-        return;
-    }
-
-    const bool bSettingsChanged = !PostProcessSettings.Equals(CachedPostProcessSettings);
-    const bool bWeightChanged = !FMath::IsNearlyEqual(PostProcessBlendWeight, CachedBlendWeight);
-
-    if (!bPostProcessApplied || bSettingsChanged || bWeightChanged)
-    {
-        AActor* OwnerActor = GetOwner();
-        APlayerController* PC = nullptr;
-        if (APawn* OwnerPawn = Cast<APawn>(OwnerActor))
-        {
-            PC = Cast<APlayerController>(OwnerPawn->GetController());
-        }
-        if (!PC && OwnerActor)
-        {
-            PC = Cast<APlayerController>(OwnerActor->GetInstigatorController());
-        }
-        if (PC && PC->PlayerCameraManager)
-        {
-            PC->PlayerCameraManager->AddCachedPPBlend(PostProcessSettings, PostProcessBlendWeight);
-            CachedPostProcessSettings = PostProcessSettings;
-            CachedBlendWeight = PostProcessBlendWeight;
-            bPostProcessApplied = true;
-        }
-    }
-}
-

--- a/Source/ALSReplicated/Public/Camera/CinematicCameraComponent.h
+++ b/Source/ALSReplicated/Public/Camera/CinematicCameraComponent.h
@@ -1,25 +1,20 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "GameFramework/SpringArmComponent.h"
+#include "Camera/BaseCameraComponent.h"
 #include "Engine/Scene.h"
 #include "CinematicCameraComponent.generated.h"
 
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
-class ALSREPLICATED_API UCinematicCameraComponent : public USpringArmComponent
+class ALSREPLICATED_API UCinematicCameraComponent : public UBaseCameraComponent
 {
     GENERATED_BODY()
 
 public:
     UCinematicCameraComponent();
 
-    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-
     UFUNCTION(BlueprintCallable, Category="Camera")
     void SwitchShoulder();
-
-    UFUNCTION(BlueprintCallable, Category="Camera")
-    void SetDesiredArmLength(float Length);
 
     UFUNCTION(BlueprintCallable, Category="Camera")
     void EnterFocusMode(AActor* Target);
@@ -27,13 +22,6 @@ public:
     UFUNCTION(BlueprintCallable, Category="Camera")
     void ExitFocusMode();
 
-    /** Called after the camera shoulder is changed. bRight is the new side. */
-    UFUNCTION(BlueprintImplementableEvent, Category="Camera")
-    void OnShoulderSwitched(bool bRight);
-
-    /** Fired whenever DesiredArmLength is updated. Use to drive zoom effects. */
-    UFUNCTION(BlueprintImplementableEvent, Category="Camera")
-    void OnZoomChanged(float NewLength);
 
     /** Triggered when focus mode begins on Target. */
     UFUNCTION(BlueprintImplementableEvent, Category="Camera")
@@ -44,45 +32,12 @@ public:
     void OnFocusModeEnded();
 
 protected:
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Shoulder")
-    float ShoulderOffset = 50.f;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Shoulder")
-    bool bRightShoulder = true;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lag")
-    bool bEnableLag = true;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Lag", meta=(EditCondition="bEnableLag"))
-    float LagSpeed = 10.f;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Zoom")
-    float ZoomInterpSpeed = 5.f;
-
-    UPROPERTY(BlueprintReadWrite, Category="Zoom")
-    float DesiredArmLength = 300.f;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess")
-    bool bUsePostProcess = false;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess", meta=(EditCondition="bUsePostProcess"))
-    FPostProcessSettings PostProcessSettings;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PostProcess", meta=(EditCondition="bUsePostProcess"))
-    float PostProcessBlendWeight = 1.f;
-
-    /** Update the cached post process blend when settings change */
-    UFUNCTION(BlueprintCallable, Category="PostProcess")
-    void UpdatePostProcess();
-
-    bool bPostProcessApplied = false;
-    FPostProcessSettings CachedPostProcessSettings;
-    float CachedBlendWeight = 0.f;
-
     UPROPERTY(BlueprintReadWrite, Category="Focus")
     bool bFocusMode = false;
 
     UPROPERTY(BlueprintReadWrite, Category="Focus")
     AActor* FocusTarget = nullptr;
+
+    virtual void UpdateOrientation(float DeltaTime) override;
 };
 


### PR DESCRIPTION
## Summary
- inherit from `UBaseCameraComponent` in Cinematic camera component
- remove duplicated properties and methods
- override `UpdateOrientation` only
- call `Super` in the constructor

## Testing
- `UE4Editor -run=AutomationTest FCinematicCameraTickTest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a29fe1a0c8331a8d7c19e7fd76319