### PR TITLE
Add CharacterStateCoordinator component

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ A description of what actually happens.
 
 `UCombatComponent` exposes the `OnAttackStateChanged` event which is triggered whenever an attack begins or ends. Implement this in your blueprint to play effects or update the UI when `bAttacking` is `true` or `false`.
 
+`UCharacterStateCoordinator` coordinates high level states like **Combat**, **Stealth** and **Exploration**. Other components may subscribe to its events:
+
+* `OnCombatEngaged` &ndash; fired when the coordinator enters the Combat state.
+* `OnStaminaCritical` &ndash; fired when the owning character's stamina is depleted.
+* `OnTraversalAction` &ndash; call `NotifyTraversalAction()` to broadcast custom traversal events such as climbing or vaulting.
+
+These events make it easy for Blueprints to react to state changes or trigger UI updates without coupling systems together.
+
 
 ## Automation Tests
 

--- a/Source/ALSReplicated/Private/CharacterStateCoordinator.cpp
+++ b/Source/ALSReplicated/Private/CharacterStateCoordinator.cpp
@@ -1,0 +1,67 @@
+#include "CharacterStateCoordinator.h"
+#include "StaminaComponent.h"
+#include "GameFramework/Actor.h"
+
+UCharacterStateCoordinator::UCharacterStateCoordinator()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UCharacterStateCoordinator::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (AActor* Owner = GetOwner())
+    {
+        CachedStamina = Owner->FindComponentByClass<UStaminaComponent>();
+        if (CachedStamina)
+        {
+            CachedStamina->OnStaminaDepleted.AddDynamic(this, &UCharacterStateCoordinator::HandleStaminaDepleted);
+        }
+    }
+}
+
+void UCharacterStateCoordinator::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UCharacterStateCoordinator, CurrentState);
+}
+
+void UCharacterStateCoordinator::SetCharacterState(ECharacterActivityState NewState)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerSetCharacterState(NewState);
+        return;
+    }
+    if (CurrentState != NewState)
+    {
+        CurrentState = NewState;
+        OnRep_State();
+    }
+}
+
+void UCharacterStateCoordinator::ServerSetCharacterState_Implementation(ECharacterActivityState NewState)
+{
+    SetCharacterState(NewState);
+}
+
+void UCharacterStateCoordinator::OnRep_State()
+{
+    if (CurrentState == ECharacterActivityState::Combat)
+    {
+        OnCombatEngaged.Broadcast();
+    }
+}
+
+void UCharacterStateCoordinator::NotifyTraversalAction()
+{
+    OnTraversalAction.Broadcast();
+}
+
+void UCharacterStateCoordinator::HandleStaminaDepleted()
+{
+    OnStaminaCritical.Broadcast();
+}
+

--- a/Source/ALSReplicated/Public/CharacterStateCoordinator.h
+++ b/Source/ALSReplicated/Public/CharacterStateCoordinator.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "CharacterStateCoordinator.generated.h"
+
+UENUM(BlueprintType)
+enum class ECharacterActivityState : uint8
+{
+    Exploration,
+    Stealth,
+    Combat
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FCharacterStateEvent);
+
+/**
+ * Coordinates overall character state and broadcasts events when key changes occur.
+ */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UCharacterStateCoordinator : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UCharacterStateCoordinator();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    UFUNCTION(BlueprintCallable, Category="State")
+    void SetCharacterState(ECharacterActivityState NewState);
+
+    UFUNCTION(BlueprintCallable, Category="State")
+    ECharacterActivityState GetCharacterState() const { return CurrentState; }
+
+    UFUNCTION(BlueprintCallable, Category="State")
+    void NotifyTraversalAction();
+
+    UPROPERTY(BlueprintAssignable)
+    FCharacterStateEvent OnCombatEngaged;
+
+    UPROPERTY(BlueprintAssignable)
+    FCharacterStateEvent OnStaminaCritical;
+
+    UPROPERTY(BlueprintAssignable)
+    FCharacterStateEvent OnTraversalAction;
+
+protected:
+    virtual void BeginPlay() override;
+
+    UFUNCTION(Server, Reliable)
+    void ServerSetCharacterState(ECharacterActivityState NewState);
+
+    UFUNCTION()
+    void OnRep_State();
+
+    UFUNCTION()
+    void HandleStaminaDepleted();
+
+    UPROPERTY(ReplicatedUsing=OnRep_State)
+    ECharacterActivityState CurrentState = ECharacterActivityState::Exploration;
+
+    UPROPERTY()
+    class UStaminaComponent* CachedStamina = nullptr;
+};
+


### PR DESCRIPTION
## Summary
- create `UCharacterStateCoordinator` component with replicated state
- broadcast `OnCombatEngaged`, `OnStaminaCritical`, `OnTraversalAction` events
- document new coordinator usage in README

## Testing
- `echo "No tests defined"`

------
https://chatgpt.com/codex/tasks/task_e_686a57b928148331a8099fdde7535b2e