### PR TITLE
Add emotion state component and sample BT node

### DIFF
--- a/Source/ALSReplicated/Private/AI/AAAController.cpp
+++ b/Source/ALSReplicated/Private/AI/AAAController.cpp
@@ -1,7 +1,9 @@
 #include "AI/AAAController.h"
+#include "AI/EmotionStateComponent.h"
 #include "Perception/AIPerceptionComponent.h"
 #include "Perception/AISenseConfig_Sight.h"
 #include "Perception/AISenseConfig_Hearing.h"
+#include "BehaviorTree/BlackboardComponent.h"
 #include "Net/UnrealNetwork.h"
 
 AALSBaseAIController::AALSBaseAIController()
@@ -11,6 +13,7 @@ AALSBaseAIController::AALSBaseAIController()
     PerceptionComponent = CreateDefaultSubobject<UAIPerceptionComponent>(TEXT("PerceptionComponent"));
     SightConfig = CreateDefaultSubobject<UAISenseConfig_Sight>(TEXT("SightConfig"));
     HearingConfig = CreateDefaultSubobject<UAISenseConfig_Hearing>(TEXT("HearingConfig"));
+    EmotionComponent = CreateDefaultSubobject<UEmotionStateComponent>(TEXT("EmotionComponent"));
 
     if (PerceptionComponent)
     {
@@ -39,6 +42,15 @@ void AALSBaseAIController::OnTargetPerceptionUpdated(AActor* Actor, FAIStimulus 
     {
         CurrentTarget = nullptr;
         OnRep_CurrentTarget();
+    }
+
+    if (EmotionComponent)
+    {
+        EmotionComponent->HandlePerception(Stimulus.WasSuccessfullySensed());
+        if (UBlackboardComponent* BB = GetBlackboardComponent())
+        {
+            BB->SetValueAsEnum(TEXT("Emotion"), (uint8)EmotionComponent->GetEmotion());
+        }
     }
 }
 

--- a/Source/ALSReplicated/Private/AI/EmotionStateComponent.cpp
+++ b/Source/ALSReplicated/Private/AI/EmotionStateComponent.cpp
@@ -1,0 +1,41 @@
+#include "AI/EmotionStateComponent.h"
+#include "Net/UnrealNetwork.h"
+
+UEmotionStateComponent::UEmotionStateComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UEmotionStateComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UEmotionStateComponent, CurrentEmotion);
+}
+
+void UEmotionStateComponent::SetEmotion(EEmotionState NewEmotion)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        return;
+    }
+    CurrentEmotion = NewEmotion;
+    OnRep_Emotion();
+}
+
+void UEmotionStateComponent::HandlePerception(bool bSensedEnemy)
+{
+    if (bSensedEnemy)
+    {
+        SetEmotion(EEmotionState::Aggression);
+    }
+    else
+    {
+        SetEmotion(EEmotionState::Calm);
+    }
+}
+
+void UEmotionStateComponent::OnRep_Emotion()
+{
+    // Placeholder for reactions when emotion changes
+}

--- a/Source/ALSReplicated/Private/AI/Tasks/BTTask_SetEmotion.cpp
+++ b/Source/ALSReplicated/Private/AI/Tasks/BTTask_SetEmotion.cpp
@@ -1,0 +1,26 @@
+#include "AI/Tasks/BTTask_SetEmotion.h"
+#include "AI/EmotionStateComponent.h"
+#include "AIController.h"
+
+UBTTask_SetEmotion::UBTTask_SetEmotion()
+{
+    NodeName = TEXT("Set Emotion");
+    NewEmotion = EEmotionState::Calm;
+}
+
+EBTNodeResult::Type UBTTask_SetEmotion::ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
+{
+    AAIController* Controller = OwnerComp.GetAIOwner();
+    if (!Controller)
+    {
+        return EBTNodeResult::Failed;
+    }
+
+    if (UEmotionStateComponent* Emotion = Controller->FindComponentByClass<UEmotionStateComponent>())
+    {
+        Emotion->SetEmotion(NewEmotion);
+        return EBTNodeResult::Succeeded;
+    }
+
+    return EBTNodeResult::Failed;
+}

--- a/Source/ALSReplicated/Private/Tests/EmotionStateReplicationTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/EmotionStateReplicationTests.cpp
@@ -1,0 +1,16 @@
+#include "Misc/AutomationTest.h"
+#include "AI/EmotionStateComponent.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FEmotionStateReplicationTest, "ALSReplicated.EmotionState.Replication", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FEmotionStateReplicationTest::RunTest(const FString& Parameters)
+{
+    UClass* EmotionClass = UEmotionStateComponent::StaticClass();
+    FProperty* Prop = EmotionClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UEmotionStateComponent, CurrentEmotion));
+    const bool bReplicated = Prop && Prop->HasAnyPropertyFlags(CPF_Net);
+    TestTrue(TEXT("CurrentEmotion should replicate"), bReplicated);
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ALSReplicated/Public/AI/AAAController.h
+++ b/Source/ALSReplicated/Public/AI/AAAController.h
@@ -8,6 +8,7 @@
 class UAIPerceptionComponent;
 class UAISenseConfig_Sight;
 class UAISenseConfig_Hearing;
+class UEmotionStateComponent;
 
 /**
  * Basic AI controller used for replicated AI characters.
@@ -31,6 +32,9 @@ protected:
 
     UPROPERTY()
     UAISenseConfig_Hearing* HearingConfig;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="AI")
+    UEmotionStateComponent* EmotionComponent;
 
     UFUNCTION()
     void OnTargetPerceptionUpdated(AActor* Actor, FAIStimulus Stimulus);

--- a/Source/ALSReplicated/Public/AI/EmotionStateComponent.h
+++ b/Source/ALSReplicated/Public/AI/EmotionStateComponent.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "EmotionStateComponent.generated.h"
+
+UENUM(BlueprintType)
+enum class EEmotionState : uint8
+{
+    Calm,
+    Alert,
+    Fear,
+    Aggression,
+    Confused
+};
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UEmotionStateComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UEmotionStateComponent();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    UFUNCTION(BlueprintCallable, Category="Emotion")
+    void SetEmotion(EEmotionState NewEmotion);
+
+    UFUNCTION(BlueprintCallable, Category="Emotion")
+    EEmotionState GetEmotion() const { return CurrentEmotion; }
+
+    void HandlePerception(bool bSensedEnemy);
+
+protected:
+    UPROPERTY(ReplicatedUsing=OnRep_Emotion, EditAnywhere, BlueprintReadOnly, Category="Emotion")
+    EEmotionState CurrentEmotion = EEmotionState::Calm;
+
+    UFUNCTION()
+    void OnRep_Emotion();
+};

--- a/Source/ALSReplicated/Public/AI/Tasks/BTTask_SetEmotion.h
+++ b/Source/ALSReplicated/Public/AI/Tasks/BTTask_SetEmotion.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BehaviorTree/BTTaskNode.h"
+#include "EmotionStateComponent.h"
+#include "BTTask_SetEmotion.generated.h"
+
+/** Sets the emotion state on the controller */
+UCLASS()
+class ALSREPLICATED_API UBTTask_SetEmotion : public UBTTaskNode
+{
+    GENERATED_BODY()
+public:
+    UBTTask_SetEmotion();
+
+    virtual EBTNodeResult::Type ExecuteTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
+
+    UPROPERTY(EditAnywhere, Category="Emotion")
+    EEmotionState NewEmotion;
+};


### PR DESCRIPTION
## Summary
- add `UEmotionStateComponent` with replication
- integrate component in `AALSBaseAIController`
- update perception callback to update blackboard emotion key
- implement `BTTask_SetEmotion` as an example usage
- add automation test for replication of the emotion state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a63fb61048331b9280a9592ad330e