### PR TITLE
Add replication and state automation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ These events make it easy for Blueprints to react to state changes or trigger UI
 
 ## Automation Tests
 
-A set of automation tests validates component replication. Open **Session Frontend** in the Unreal Editor and run the tests under `ALSReplicated.ComponentReplication`, `ALSReplicated.StaminaReplication`, `ALSReplicated.LockOn.TargetReplication` and `ALSReplicated.EnvironmentInteractionReplication`. Alternatively, run them from the command line:
+A set of automation tests validates component replication and event behavior. Open **Session Frontend** in the Unreal Editor and run the tests under `ALSReplicated.ComponentReplication`, `ALSReplicated.StaminaReplication`, `ALSReplicated.LockOn.TargetReplication`, `ALSReplicated.EnvironmentInteractionReplication`, `ALSReplicated.Stamina.Events`, `ALSReplicated.CharacterStateCoordinator.Events` and `ALSReplicated.EmotionState.Transitions`. Alternatively, run them from the command line:
 
 ```
 UE4Editor.exe <YourProject>.uproject -run=Automation -test=ALSReplicated.* -unattended

--- a/Source/ALSReplicated/Private/Tests/CharacterStateCoordinatorEventTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/CharacterStateCoordinatorEventTests.cpp
@@ -1,0 +1,33 @@
+#include "Misc/AutomationTest.h"
+#include "CharacterStateCoordinator.h"
+#include "StaminaComponent.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCharacterStateCoordinatorEventsTest, "ALSReplicated.CharacterStateCoordinator.Events", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FCharacterStateCoordinatorEventsTest::RunTest(const FString& Parameters)
+{
+    UCharacterStateCoordinator* Coordinator = NewObject<UCharacterStateCoordinator>();
+    int32 CombatCount = 0;
+    int32 CriticalCount = 0;
+    int32 TraverseCount = 0;
+
+    Coordinator->OnCombatEngaged.AddLambda([&]() { ++CombatCount; });
+    Coordinator->OnStaminaCritical.AddLambda([&]() { ++CriticalCount; });
+    Coordinator->OnTraversalAction.AddLambda([&]() { ++TraverseCount; });
+
+    Coordinator->SetCharacterState(ECharacterActivityState::Combat);
+    TestEqual(TEXT("OnCombatEngaged fired"), CombatCount, 1);
+
+    UStaminaComponent* Stamina = NewObject<UStaminaComponent>();
+    Stamina->OnStaminaDepleted.AddDynamic(Coordinator, &UCharacterStateCoordinator::HandleStaminaDepleted);
+    Stamina->OnStaminaDepleted.Broadcast();
+    TestEqual(TEXT("OnStaminaCritical fired"), CriticalCount, 1);
+
+    Coordinator->NotifyTraversalAction();
+    TestEqual(TEXT("OnTraversalAction fired"), TraverseCount, 1);
+
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ALSReplicated/Private/Tests/EmotionStateReplicationTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/EmotionStateReplicationTests.cpp
@@ -13,4 +13,16 @@ bool FEmotionStateReplicationTest::RunTest(const FString& Parameters)
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FEmotionStateTransitionTest, "ALSReplicated.EmotionState.Transitions", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FEmotionStateTransitionTest::RunTest(const FString& Parameters)
+{
+    UEmotionStateComponent* Emotion = NewObject<UEmotionStateComponent>();
+    Emotion->HandlePerception(true);
+    TestEqual(TEXT("Perceiving an enemy sets Aggression"), Emotion->GetEmotion(), EEmotionState::Aggression);
+
+    Emotion->HandlePerception(false);
+    TestEqual(TEXT("Losing sight returns to Calm"), Emotion->GetEmotion(), EEmotionState::Calm);
+    return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ALSReplicated/Private/Tests/StaminaEventTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/StaminaEventTests.cpp
@@ -1,0 +1,25 @@
+#include "Misc/AutomationTest.h"
+#include "StaminaComponent.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FStaminaEventBroadcastTest, "ALSReplicated.Stamina.Events", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FStaminaEventBroadcastTest::RunTest(const FString& Parameters)
+{
+    UStaminaComponent* Stamina = NewObject<UStaminaComponent>();
+    int32 DepletedCount = 0;
+    int32 RecoveredCount = 0;
+    Stamina->OnStaminaDepleted.AddLambda([&]() { ++DepletedCount; });
+    Stamina->OnStaminaRecovered.AddLambda([&]() { ++RecoveredCount; });
+
+    Stamina->AddStamina(-200.f);
+    TestEqual(TEXT("OnStaminaDepleted fired once"), DepletedCount, 1);
+    TestEqual(TEXT("OnStaminaRecovered not yet fired"), RecoveredCount, 0);
+
+    Stamina->AddStamina(50.f);
+    TestEqual(TEXT("OnStaminaRecovered fired once"), RecoveredCount, 1);
+
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
## Summary
- add test verifying stamina component events fire correctly
- add tests for character state coordinator event broadcasts
- add transition tests for emotion state component
- document new automation test categories

## Testing
- `UE4Editor --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0b5a30fc8331b5d31b410c81f7df