### PR TITLE
Handle missing world when spawning impact visuals

### DIFF
--- a/Source/ALSReplicated/Private/VisualImpactSystem.cpp
+++ b/Source/ALSReplicated/Private/VisualImpactSystem.cpp
@@ -9,7 +9,13 @@ void UVisualImpactSystem::SpawnDirectionalNiagaraFX(UObject* WorldContextObject,
         return;
     }
 
-    UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject);
+    UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject);
+    if (!World)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("SpawnDirectionalNiagaraFX: Invalid world context object"));
+        return;
+    }
+
     UNiagaraFunctionLibrary::SpawnSystemAtLocation(World, FX, Location, Direction.Rotation());
 
     if (CameraShake && Force >= ShakeThreshold)
@@ -28,7 +34,13 @@ void UVisualImpactSystem::SpawnImpactDecal(UObject* WorldContextObject, UMateria
         return;
     }
 
-    UWorld* World = GEngine->GetWorldFromContextObjectChecked(WorldContextObject);
+    UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject);
+    if (!World)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("SpawnImpactDecal: Invalid world context object"));
+        return;
+    }
+
     UGameplayStatics::SpawnDecalAtLocation(World, Decal, Size, Location, Direction.Rotation(), LifeSpan);
 }
 


### PR DESCRIPTION
## Summary
- prevent crashes when world context object is null
- log warnings when failing to spawn impact FX or decals

## Testing
- `UE4Editor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2bbe7458833186307f01e6a6296a