### PR TITLE
Add state change delegate and test

### DIFF
--- a/Source/ALSReplicated/Private/CharacterStateCoordinator.cpp
+++ b/Source/ALSReplicated/Private/CharacterStateCoordinator.cpp
@@ -38,6 +38,7 @@ void UCharacterStateCoordinator::SetCharacterState(ECharacterActivityState NewSt
     if (CurrentState != NewState)
     {
         CurrentState = NewState;
+        OnStateChanged.Broadcast(CurrentState);
         OnRep_State();
     }
 }
@@ -52,6 +53,11 @@ void UCharacterStateCoordinator::OnRep_State()
     if (CurrentState == ECharacterActivityState::Combat)
     {
         OnCombatEngaged.Broadcast();
+    }
+
+    if (GetOwnerRole() != ROLE_Authority)
+    {
+        OnStateChanged.Broadcast(CurrentState);
     }
 }
 

--- a/Source/ALSReplicated/Private/Tests/CharacterStateCoordinatorEventTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/CharacterStateCoordinatorEventTests.cpp
@@ -30,4 +30,24 @@ bool FCharacterStateCoordinatorEventsTest::RunTest(const FString& Parameters)
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCharacterStateCoordinatorStateChangeTest, "ALSReplicated.CharacterStateCoordinator.StateChanged", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FCharacterStateCoordinatorStateChangeTest::RunTest(const FString& Parameters)
+{
+    UCharacterStateCoordinator* Coordinator = NewObject<UCharacterStateCoordinator>();
+    int32 ChangeCount = 0;
+    ECharacterActivityState LastState = ECharacterActivityState::Exploration;
+    Coordinator->OnStateChanged.AddLambda([&](ECharacterActivityState NewState)
+    {
+        ++ChangeCount;
+        LastState = NewState;
+    });
+
+    Coordinator->SetCharacterState(ECharacterActivityState::Combat);
+
+    TestEqual(TEXT("OnStateChanged fired"), ChangeCount, 1);
+    TestEqual(TEXT("New state reported"), LastState, ECharacterActivityState::Combat);
+
+    return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ALSReplicated/Public/CharacterStateCoordinator.h
+++ b/Source/ALSReplicated/Public/CharacterStateCoordinator.h
@@ -14,6 +14,7 @@ enum class ECharacterActivityState : uint8
 };
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FCharacterStateEvent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCharacterStateChanged, ECharacterActivityState, NewState);
 
 /**
  * Coordinates overall character state and broadcasts events when key changes occur.
@@ -44,6 +45,10 @@ public:
 
     UPROPERTY(BlueprintAssignable)
     FCharacterStateEvent OnTraversalAction;
+
+    /** Broadcasts whenever the character activity state changes */
+    UPROPERTY(BlueprintAssignable)
+    FCharacterStateChanged OnStateChanged;
 
 protected:
     virtual void BeginPlay() override;


### PR DESCRIPTION
## Summary
- add `FCharacterStateChanged` delegate and `OnStateChanged` event to the coordinator
- broadcast new event when state changes
- broadcast on replication
- test that the delegate fires when transitioning from Exploration to Combat

## Testing
- `RunUAT.sh -run=AutomationTests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686b4b61c6ec8331b1b93c2e0eb4e5c0