### PR TITLE
Add stance change event

### DIFF
--- a/Source/ALSReplicated/Private/StanceManagerComponent.cpp
+++ b/Source/ALSReplicated/Private/StanceManagerComponent.cpp
@@ -36,9 +36,12 @@ void UStanceManagerComponent::SetStance(EStanceMode NewStance)
         ServerSetStance(NewStance);
         return;
     }
-
-    CurrentStance = NewStance;
-    ApplyStance();
+    if (CurrentStance != NewStance)
+    {
+        CurrentStance = NewStance;
+        OnStanceChanged.Broadcast(CurrentStance);
+        ApplyStance();
+    }
 }
 
 void UStanceManagerComponent::ServerSetStance_Implementation(EStanceMode NewStance)
@@ -49,6 +52,10 @@ void UStanceManagerComponent::ServerSetStance_Implementation(EStanceMode NewStan
 void UStanceManagerComponent::OnRep_Stance()
 {
     ApplyStance();
+    if (GetOwnerRole() != ROLE_Authority)
+    {
+        OnStanceChanged.Broadcast(CurrentStance);
+    }
 }
 
 void UStanceManagerComponent::ApplyStance()

--- a/Source/ALSReplicated/Private/Tests/StanceManagerReplicationTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/StanceManagerReplicationTests.cpp
@@ -10,6 +10,28 @@ bool FStanceManagerCurrentStanceReplicationTest::RunTest(const FString& Paramete
     FProperty* Prop = StanceClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UStanceManagerComponent, CurrentStance));
     const bool bReplicated = Prop && Prop->HasAnyPropertyFlags(CPF_Net);
     TestTrue(TEXT("CurrentStance should replicate"), bReplicated);
+
+    class UTestStanceManagerComponent : public UStanceManagerComponent
+    {
+    public:
+        using UStanceManagerComponent::OnRep_Stance;
+    };
+
+    UTestStanceManagerComponent* Comp = NewObject<UTestStanceManagerComponent>();
+    int32 ChangeCount = 0;
+    EStanceMode LastStance = EStanceMode::Normal;
+    Comp->OnStanceChanged.AddLambda([&](EStanceMode NewStance)
+    {
+        ++ChangeCount;
+        LastStance = NewStance;
+    });
+
+    Comp->CurrentStance = EStanceMode::Aggressive;
+    Comp->OnRep_Stance();
+
+    TestEqual(TEXT("OnStanceChanged fired via OnRep_Stance"), ChangeCount, 1);
+    TestEqual(TEXT("New stance replicated"), LastStance, EStanceMode::Aggressive);
+
     return true;
 }
 

--- a/Source/ALSReplicated/Public/StanceManagerComponent.h
+++ b/Source/ALSReplicated/Public/StanceManagerComponent.h
@@ -14,6 +14,9 @@ enum class EStanceMode : uint8
     Aggressive
 };
 
+/** Notifies listeners when the stance changes */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FStanceChanged, EStanceMode, NewStance);
+
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class ALSREPLICATED_API UStanceManagerComponent : public UActorComponent
 {
@@ -28,6 +31,10 @@ public:
 
     UFUNCTION(BlueprintCallable, Category="Stance")
     EStanceMode GetStance() const { return CurrentStance; }
+
+    /** Fired whenever the stance changes */
+    UPROPERTY(BlueprintAssignable)
+    FStanceChanged OnStanceChanged;
 
 protected:
     virtual void BeginPlay() override;


### PR DESCRIPTION
## Summary
- add `FStanceChanged` delegate and `OnStanceChanged` property
- broadcast `OnStanceChanged` when stance changes
- extend stance replication test to verify `OnRep_Stance` broadcasts the event

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686b5dbb62248331bc4d8568f7e23132