### PR TITLE
Add dash root motion support

### DIFF
--- a/Source/ALSReplicated/Private/Tests/DashRootMotionTests.cpp
+++ b/Source/ALSReplicated/Private/Tests/DashRootMotionTests.cpp
@@ -1,0 +1,16 @@
+#include "Misc/AutomationTest.h"
+#include "CombatComponent.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDashRootMotionReplicationTest, "ALSReplicated.Combat.DashRootMotionReplication", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FDashRootMotionReplicationTest::RunTest(const FString& Parameters)
+{
+    UClass* CombatClass = UCombatComponent::StaticClass();
+    FProperty* Prop = CombatClass->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UCombatComponent, bUseDashRootMotion));
+    const bool bReplicated = Prop && Prop->HasAnyPropertyFlags(CPF_Net);
+    TestTrue(TEXT("bUseDashRootMotion should replicate"), bReplicated);
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/ALSReplicated/Public/CombatComponent.h
+++ b/Source/ALSReplicated/Public/CombatComponent.h
@@ -34,6 +34,10 @@ public:
     UFUNCTION(BlueprintCallable, Category="Combat")
     void SpawnHitbox();
 
+    /** Performs a dash using the DashMontage */
+    UFUNCTION(BlueprintCallable, Category="Combat")
+    void PerformDash();
+
     /** Add stamina back. Can be used by other systems */
     UFUNCTION(BlueprintCallable, Category="Combat")
     void AddStamina(float Amount);
@@ -62,6 +66,12 @@ protected:
     UFUNCTION(Server, Reliable, WithValidation)
     void ServerUnequipWeapon();
 
+    UFUNCTION(Server, Reliable)
+    void ServerPerformDash();
+
+    UFUNCTION(NetMulticast, Reliable)
+    void MulticastPerformDash();
+
     void DoAttack(bool bHeavy);
     void FinishAttack();
     void ResetCombo();
@@ -85,6 +95,7 @@ protected:
     FTimerHandle ComboTimerHandle;
     FTimerHandle AttackTimerHandle;
     FTimerHandle CooldownTimerHandle;
+    FTimerHandle DashTimerHandle;
 
     UPROPERTY(EditDefaultsOnly, Category="Combat")
     float LightAttackStaminaCost = 20.f;
@@ -111,6 +122,14 @@ protected:
 
     UPROPERTY(EditDefaultsOnly, Category="Combat")
     UAnimMontage* HeavyAttackMontage;
+
+    /** Montage used when performing a dash */
+    UPROPERTY(EditDefaultsOnly, Category="Combat")
+    UAnimMontage* DashMontage = nullptr;
+
+    /** If true the dash montage will use root motion */
+    UPROPERTY(Replicated, EditDefaultsOnly, Category="Combat")
+    bool bUseDashRootMotion = false;
 
     UPROPERTY()
     AActor* EquippedWeapon = nullptr;


### PR DESCRIPTION
## Summary
- add dash montage and root motion flag to `CombatComponent`
- implement `PerformDash` with root motion playback
- trigger dash from HeavyAttack while moving
- unit test for dash root motion replication flag

## Testing
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c4b48788331a4563b8d719896c4