### PR TITLE
Add menu manager and placeholder UI widgets

### DIFF
--- a/Content/UI/WBP_Keybinding.uasset
+++ b/Content/UI/WBP_Keybinding.uasset
@@ -1,0 +1,1 @@
+Placeholder Widget

--- a/Content/UI/WBP_MainMenu.uasset
+++ b/Content/UI/WBP_MainMenu.uasset
@@ -1,0 +1,1 @@
+Placeholder Widget

--- a/Content/UI/WBP_OptionsGraphicsAudio.uasset
+++ b/Content/UI/WBP_OptionsGraphicsAudio.uasset
@@ -1,0 +1,1 @@
+Placeholder Widget

--- a/Source/ALSReplicated/Private/MenuManager.cpp
+++ b/Source/ALSReplicated/Private/MenuManager.cpp
@@ -1,0 +1,71 @@
+#include "MenuManager.h"
+#include "Blueprint/UserWidget.h"
+#include "GameFramework/PlayerController.h"
+#include "Engine/Engine.h"
+#include "Kismet/GameplayStatics.h"
+#include "GameFramework/GameUserSettings.h"
+
+void UMenuManager::ShowMainMenu()
+{
+    ShowWidget(MainMenuClass);
+}
+
+void UMenuManager::ShowOptionsMenu()
+{
+    ShowWidget(OptionsMenuClass);
+}
+
+void UMenuManager::ShowKeybindMenu()
+{
+    ShowWidget(KeybindMenuClass);
+}
+
+void UMenuManager::SaveSettings()
+{
+    if (UGameUserSettings* Settings = GEngine->GetGameUserSettings())
+    {
+        Settings->ApplySettings(false);
+        Settings->SaveSettings();
+    }
+}
+
+void UMenuManager::Deinitialize()
+{
+    if (CurrentWidget)
+    {
+        CurrentWidget->RemoveFromParent();
+        CurrentWidget = nullptr;
+    }
+    Super::Deinitialize();
+}
+
+void UMenuManager::ShowWidget(TSubclassOf<UUserWidget> WidgetClass)
+{
+    if (!WidgetClass)
+    {
+        return;
+    }
+    if (CurrentWidget)
+    {
+        CurrentWidget->RemoveFromParent();
+        CurrentWidget = nullptr;
+    }
+    UWorld* World = GetWorld();
+    if (!World)
+    {
+        return;
+    }
+    if (APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0))
+    {
+        CurrentWidget = CreateWidget<UUserWidget>(PC, WidgetClass);
+        if (CurrentWidget)
+        {
+            CurrentWidget->AddToViewport();
+            FInputModeUIOnly InputMode;
+            InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+            InputMode.SetWidgetToFocus(CurrentWidget->TakeWidget());
+            PC->SetInputMode(InputMode);
+            PC->bShowMouseCursor = true;
+        }
+    }
+}

--- a/Source/ALSReplicated/Public/MenuManager.h
+++ b/Source/ALSReplicated/Public/MenuManager.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "MenuManager.generated.h"
+
+class UUserWidget;
+
+/** Simple subsystem used to toggle UI menus and persist user settings. */
+UCLASS()
+class ALSREPLICATED_API UMenuManager : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Show the main menu widget */
+    UFUNCTION(BlueprintCallable, Category="Menu")
+    void ShowMainMenu();
+
+    /** Show the graphics and audio options menu */
+    UFUNCTION(BlueprintCallable, Category="Menu")
+    void ShowOptionsMenu();
+
+    /** Show the keybinding menu */
+    UFUNCTION(BlueprintCallable, Category="Menu")
+    void ShowKeybindMenu();
+
+    /** Save current user settings to config */
+    UFUNCTION(BlueprintCallable, Category="Menu")
+    void SaveSettings();
+
+protected:
+    virtual void Deinitialize() override;
+
+    UPROPERTY()
+    UUserWidget* CurrentWidget = nullptr;
+
+    UPROPERTY(EditDefaultsOnly, Category="Menu")
+    TSubclassOf<UUserWidget> MainMenuClass;
+
+    UPROPERTY(EditDefaultsOnly, Category="Menu")
+    TSubclassOf<UUserWidget> OptionsMenuClass;
+
+    UPROPERTY(EditDefaultsOnly, Category="Menu")
+    TSubclassOf<UUserWidget> KeybindMenuClass;
+
+    void ShowWidget(TSubclassOf<UUserWidget> WidgetClass);
+};


### PR DESCRIPTION
## Summary
- add placeholder widgets for main menu, options, and keybindings
- implement `UMenuManager` subsystem for activating menus and saving settings

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_686b9b34d53483318fc42ed9bd4a4da5