### PR TITLE
Add atmosphere manager with replicated weather

### DIFF
--- a/Source/ALSReplicated/Private/AtmosphereManager.cpp
+++ b/Source/ALSReplicated/Private/AtmosphereManager.cpp
@@ -1,0 +1,88 @@
+#include "AtmosphereManager.h"
+#include "Net/UnrealNetwork.h"
+
+UAtmosphereManager::UAtmosphereManager()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UAtmosphereManager::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UAtmosphereManager, TimeOfDay);
+    DOREPLIFETIME(UAtmosphereManager, bRaining);
+    DOREPLIFETIME(UAtmosphereManager, bFoggy);
+}
+
+void UAtmosphereManager::SetTimeOfDay(float NewTime)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerSetTimeOfDay(NewTime);
+        return;
+    }
+    TimeOfDay = FMath::Fmod(NewTime, 24.f);
+    OnRep_TimeOfDay();
+}
+
+bool UAtmosphereManager::ServerSetTimeOfDay_Validate(float NewTime) { return true; }
+void UAtmosphereManager::ServerSetTimeOfDay_Implementation(float NewTime) { SetTimeOfDay(NewTime); }
+
+void UAtmosphereManager::SetRaining(bool bNewRaining)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerSetRaining(bNewRaining);
+        return;
+    }
+    bRaining = bNewRaining;
+    OnRep_Rain();
+}
+
+bool UAtmosphereManager::ServerSetRaining_Validate(bool bNewRaining) { return true; }
+void UAtmosphereManager::ServerSetRaining_Implementation(bool bNewRaining) { SetRaining(bNewRaining); }
+
+void UAtmosphereManager::SetFoggy(bool bNewFoggy)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerSetFoggy(bNewFoggy);
+        return;
+    }
+    bFoggy = bNewFoggy;
+    OnRep_Fog();
+}
+
+bool UAtmosphereManager::ServerSetFoggy_Validate(bool bNewFoggy) { return true; }
+void UAtmosphereManager::ServerSetFoggy_Implementation(bool bNewFoggy) { SetFoggy(bNewFoggy); }
+
+void UAtmosphereManager::OnRep_TimeOfDay()
+{
+    UpdateLighting();
+    OnTimeOfDayChanged.Broadcast(TimeOfDay);
+}
+
+void UAtmosphereManager::OnRep_Rain()
+{
+    OnRainStateChanged.Broadcast(bRaining);
+}
+
+void UAtmosphereManager::OnRep_Fog()
+{
+    OnFogStateChanged.Broadcast(bFoggy);
+}
+
+void UAtmosphereManager::UpdateLighting()
+{
+    if (DirectionalLight)
+    {
+        FRotator Rot = FRotator((TimeOfDay / 24.f) * 360.f - 90.f, 0.f, 0.f);
+        DirectionalLight->SetActorRotation(Rot);
+    }
+    if (SkyMaterial)
+    {
+        SkyMaterial->SetScalarParameterValue(SkyTimeParameterName, TimeOfDay);
+    }
+}
+

--- a/Source/ALSReplicated/Public/AtmosphereManager.h
+++ b/Source/ALSReplicated/Public/AtmosphereManager.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Engine/DirectionalLight.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "Net/UnrealNetwork.h"
+#include "AtmosphereManager.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWeatherStateChanged, bool, bNewState);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTimeOfDayChanged, float, NewTime);
+
+/**
+ * Simple manager for time of day and weather effects.
+ */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UAtmosphereManager : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UAtmosphereManager();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    /** Directional light controlled by this manager */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Atmosphere")
+    ADirectionalLight* DirectionalLight = nullptr;
+
+    /** Sky material instance that receives the time of day parameter */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Atmosphere")
+    UMaterialInstanceDynamic* SkyMaterial = nullptr;
+
+    /** Parameter name on the sky material for the time of day value */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Atmosphere")
+    FName SkyTimeParameterName = TEXT("TimeOfDay");
+
+    /** Time of day in hours (0-24) */
+    UPROPERTY(ReplicatedUsing=OnRep_TimeOfDay, BlueprintReadOnly, Category="Atmosphere")
+    float TimeOfDay = 12.f;
+
+    /** Whether rain is active */
+    UPROPERTY(ReplicatedUsing=OnRep_Rain, BlueprintReadOnly, Category="Weather")
+    bool bRaining = false;
+
+    /** Whether fog is active */
+    UPROPERTY(ReplicatedUsing=OnRep_Fog, BlueprintReadOnly, Category="Weather")
+    bool bFoggy = false;
+
+    UFUNCTION(BlueprintCallable, Category="Atmosphere")
+    void SetTimeOfDay(float NewTime);
+
+    UFUNCTION(BlueprintCallable, Category="Atmosphere")
+    void SetRaining(bool bNewRaining);
+
+    UFUNCTION(BlueprintCallable, Category="Atmosphere")
+    void SetFoggy(bool bNewFoggy);
+
+    /** Event fired when time of day changes */
+    UPROPERTY(BlueprintAssignable)
+    FTimeOfDayChanged OnTimeOfDayChanged;
+
+    /** Event fired when rain state changes */
+    UPROPERTY(BlueprintAssignable)
+    FWeatherStateChanged OnRainStateChanged;
+
+    /** Event fired when fog state changes */
+    UPROPERTY(BlueprintAssignable)
+    FWeatherStateChanged OnFogStateChanged;
+
+protected:
+    UFUNCTION()
+    void OnRep_TimeOfDay();
+
+    UFUNCTION()
+    void OnRep_Rain();
+
+    UFUNCTION()
+    void OnRep_Fog();
+
+    UFUNCTION(Server, Reliable, WithValidation)
+    void ServerSetTimeOfDay(float NewTime);
+
+    UFUNCTION(Server, Reliable, WithValidation)
+    void ServerSetRaining(bool bNewRaining);
+
+    UFUNCTION(Server, Reliable, WithValidation)
+    void ServerSetFoggy(bool bNewFoggy);
+
+    void UpdateLighting();
+};
+


### PR DESCRIPTION
## Summary
- manage day/night lighting via `UAtmosphereManager`
- replicate rain and fog state for multiplayer
- expose Blueprint events to update time or trigger weather

## Testing
- `UnrealEditor -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c663d568483319f95ec2b5bd7d4bb