### PR TITLE
Add basic day/night and weather components

### DIFF
--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -11,7 +11,8 @@ public class ALSReplicated : ModuleRules
                 PublicIncludePaths.AddRange(
                         new string[] {
                                 System.IO.Path.Combine(ModuleDirectory, "Public"),
-                                System.IO.Path.Combine(ModuleDirectory, "Public/Camera")
+                                System.IO.Path.Combine(ModuleDirectory, "Public/Camera"),
+                                System.IO.Path.Combine(ModuleDirectory, "Public/Environment")
                         }
                         );
 				
@@ -19,7 +20,8 @@ public class ALSReplicated : ModuleRules
                 PrivateIncludePaths.AddRange(
                         new string[] {
                                 System.IO.Path.Combine(ModuleDirectory, "Private"),
-                                System.IO.Path.Combine(ModuleDirectory, "Private/Camera")
+                                System.IO.Path.Combine(ModuleDirectory, "Private/Camera"),
+                                System.IO.Path.Combine(ModuleDirectory, "Private/Environment")
                         }
                         );
 			

--- a/Source/ALSReplicated/Private/Environment/DayNightCycleComponent.cpp
+++ b/Source/ALSReplicated/Private/Environment/DayNightCycleComponent.cpp
@@ -1,0 +1,39 @@
+#include "Environment/DayNightCycleComponent.h"
+
+UDayNightCycleComponent::UDayNightCycleComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UDayNightCycleComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UDayNightCycleComponent, TimeOfDay);
+}
+
+void UDayNightCycleComponent::SetTimeOfDay(float NewTime)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerSetTimeOfDay(NewTime);
+        return;
+    }
+    TimeOfDay = FMath::Fmod(NewTime, 24.f);
+    OnRep_TimeOfDay();
+}
+
+bool UDayNightCycleComponent::ServerSetTimeOfDay_Validate(float NewTime)
+{
+    return true;
+}
+
+void UDayNightCycleComponent::ServerSetTimeOfDay_Implementation(float NewTime)
+{
+    SetTimeOfDay(NewTime);
+}
+
+void UDayNightCycleComponent::OnRep_TimeOfDay()
+{
+    OnTimeOfDayChanged.Broadcast(TimeOfDay);
+}

--- a/Source/ALSReplicated/Private/Environment/WeatherSystemComponent.cpp
+++ b/Source/ALSReplicated/Private/Environment/WeatherSystemComponent.cpp
@@ -1,0 +1,42 @@
+#include "Environment/WeatherSystemComponent.h"
+
+UWeatherSystemComponent::UWeatherSystemComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UWeatherSystemComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UWeatherSystemComponent, CurrentWeather);
+}
+
+void UWeatherSystemComponent::SetWeather(EWeatherType NewWeather)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerSetWeather(NewWeather);
+        return;
+    }
+    if (CurrentWeather != NewWeather)
+    {
+        CurrentWeather = NewWeather;
+        OnRep_Weather();
+    }
+}
+
+bool UWeatherSystemComponent::ServerSetWeather_Validate(EWeatherType NewWeather)
+{
+    return true;
+}
+
+void UWeatherSystemComponent::ServerSetWeather_Implementation(EWeatherType NewWeather)
+{
+    SetWeather(NewWeather);
+}
+
+void UWeatherSystemComponent::OnRep_Weather()
+{
+    OnWeatherChanged.Broadcast(CurrentWeather);
+}

--- a/Source/ALSReplicated/Public/Environment/DayNightCycleComponent.h
+++ b/Source/ALSReplicated/Public/Environment/DayNightCycleComponent.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "DayNightCycleComponent.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTimeOfDayChangedSignature, float, NewTime);
+
+/**
+ * Handles replicated time of day for the environment.
+ */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UDayNightCycleComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UDayNightCycleComponent();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    /** Current time of day in hours (0-24) */
+    UPROPERTY(ReplicatedUsing=OnRep_TimeOfDay, BlueprintReadOnly, Category="DayNight")
+    float TimeOfDay = 12.f;
+
+    UFUNCTION(BlueprintCallable, Category="DayNight")
+    void SetTimeOfDay(float NewTime);
+
+    /** Broadcast when TimeOfDay changes */
+    UPROPERTY(BlueprintAssignable)
+    FTimeOfDayChangedSignature OnTimeOfDayChanged;
+
+protected:
+    UFUNCTION()
+    void OnRep_TimeOfDay();
+
+    UFUNCTION(Server, Reliable, WithValidation)
+    void ServerSetTimeOfDay(float NewTime);
+};

--- a/Source/ALSReplicated/Public/Environment/WeatherSystemComponent.h
+++ b/Source/ALSReplicated/Public/Environment/WeatherSystemComponent.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "WeatherSystemComponent.generated.h"
+
+UENUM(BlueprintType)
+enum class EWeatherType : uint8
+{
+    Clear,
+    Rain,
+    Snow
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FWeatherChangedSignature, EWeatherType, NewWeather);
+
+/**
+ * Replicated weather state for the world.
+ */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UWeatherSystemComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UWeatherSystemComponent();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    UPROPERTY(ReplicatedUsing=OnRep_Weather, BlueprintReadOnly, Category="Weather")
+    EWeatherType CurrentWeather = EWeatherType::Clear;
+
+    UFUNCTION(BlueprintCallable, Category="Weather")
+    void SetWeather(EWeatherType NewWeather);
+
+    UPROPERTY(BlueprintAssignable)
+    FWeatherChangedSignature OnWeatherChanged;
+
+protected:
+    UFUNCTION()
+    void OnRep_Weather();
+
+    UFUNCTION(Server, Reliable, WithValidation)
+    void ServerSetWeather(EWeatherType NewWeather);
+};


### PR DESCRIPTION
## Summary
- add new environment include paths in build
- create `DayNightCycleComponent` and `WeatherSystemComponent`
- replicate time of day and weather state and expose blueprint events

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ca7c42c98833198a77720dc3b11f8