### PR TITLE
Add mission manager component with replication

### DIFF
--- a/Content/Quests/SampleQuest.json
+++ b/Content/Quests/SampleQuest.json
@@ -1,0 +1,5 @@
+{
+  "MissionId": "FindKey",
+  "Description": "Locate the key hidden in the level.",
+  "StageCount": 3
+}

--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ Interactive objects that you intend to push, pull or otherwise move should repli
 
 Actors involved in interactions should also enable **bReplicates** and **bReplicateMovement** in their constructors or blueprint defaults. `UEnvironmentInteractionComponent` no longer forces these flags at runtime and will only log a warning if they are missing.
 
+## Quest Setup
+
+Quests are read from DataTable or JSON assets located under `Content/Quests`. Each entry must match the `FMissionData` structure found in `UMissionManagerComponent`.
+
+1. Create a JSON file in `Content/Quests` or add rows to a DataTable using the `FMissionData` row type.
+2. Add `UMissionManagerComponent` (or `BP_MissionManagerComponent`) to your player character.
+3. Call `AdvanceMission` from Blueprint or code to update progress. Mission progress replicates automatically for all clients.
+

--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -35,6 +35,8 @@ public class ALSReplicated : ModuleRules
                                "GameplayTasks",
                                "GameplayTags",
                                "CableComponent",
+                               "Json",
+                               "JsonUtilities",
                                // ... add other public dependencies that you statically link with here ...
                        }
                        );
@@ -54,8 +56,10 @@ public class ALSReplicated : ModuleRules
                                 "GameplayTags",
                                 "NavigationSystem",
                                 "Niagara",
-                                "CableComponent",
-                                // ... add private dependencies that you statically link with here ...
+                               "CableComponent",
+                               "Json",
+                               "JsonUtilities",
+                               // ... add private dependencies that you statically link with here ...
                         }
                         );
 		

--- a/Source/ALSReplicated/Private/MissionManagerComponent.cpp
+++ b/Source/ALSReplicated/Private/MissionManagerComponent.cpp
@@ -1,0 +1,115 @@
+#include "MissionManagerComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "JsonObjectConverter.h"
+
+UMissionManagerComponent::UMissionManagerComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UMissionManagerComponent::BeginPlay()
+{
+    Super::BeginPlay();
+    LoadMissionsFromJson();
+}
+
+void UMissionManagerComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UMissionManagerComponent, MissionProgress);
+}
+
+const FMissionData* UMissionManagerComponent::GetMissionData(FName MissionId) const
+{
+    if (MissionTable)
+    {
+        return MissionTable->FindRow<FMissionData>(MissionId, TEXT("MissionLookup"));
+    }
+
+    for (const FMissionData& Data : JsonMissions)
+    {
+        if (Data.MissionId == MissionId)
+        {
+            return &Data;
+        }
+    }
+    return nullptr;
+}
+
+void UMissionManagerComponent::AdvanceMission(FName MissionId)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        ServerAdvanceMission(MissionId);
+        return;
+    }
+
+    for (FMissionProgress& Prog : MissionProgress)
+    {
+        if (Prog.MissionId == MissionId)
+        {
+            Prog.CurrentStage++;
+            const FMissionData* Data = GetMissionData(MissionId);
+            if (Data && Prog.CurrentStage >= Data->StageCount)
+            {
+                Prog.bCompleted = true;
+            }
+            OnRep_MissionProgress();
+            return;
+        }
+    }
+
+    FMissionProgress NewProgress;
+    NewProgress.MissionId = MissionId;
+    NewProgress.CurrentStage = 1;
+    const FMissionData* DataPtr = GetMissionData(MissionId);
+    if (DataPtr && NewProgress.CurrentStage >= DataPtr->StageCount)
+    {
+        NewProgress.bCompleted = true;
+    }
+    MissionProgress.Add(NewProgress);
+    OnRep_MissionProgress();
+}
+
+bool UMissionManagerComponent::ServerAdvanceMission_Validate(FName MissionId)
+{
+    return true;
+}
+
+void UMissionManagerComponent::ServerAdvanceMission_Implementation(FName MissionId)
+{
+    AdvanceMission(MissionId);
+}
+
+void UMissionManagerComponent::OnRep_MissionProgress()
+{
+    for (const FMissionProgress& Prog : MissionProgress)
+    {
+        OnMissionUpdated.Broadcast(Prog);
+    }
+}
+
+void UMissionManagerComponent::LoadMissionsFromJson()
+{
+    FString QuestDir = FPaths::ProjectContentDir() / TEXT("Quests/");
+    TArray<FString> Files;
+    IFileManager::Get().FindFiles(Files, *QuestDir, TEXT("json"));
+
+    for (const FString& File : Files)
+    {
+        FString Json;
+        FString Path = QuestDir / File;
+        if (FFileHelper::LoadFileToString(Json, *Path))
+        {
+            FMissionData Data;
+            if (FJsonObjectConverter::JsonObjectStringToUStruct(Json, &Data, 0, 0))
+            {
+                JsonMissions.Add(Data);
+            }
+        }
+    }
+}
+

--- a/Source/ALSReplicated/Public/MissionManagerComponent.h
+++ b/Source/ALSReplicated/Public/MissionManagerComponent.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "Components/ActorComponent.h"
+#include "MissionManagerComponent.generated.h"
+
+USTRUCT(BlueprintType)
+struct FMissionData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FName MissionId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FText Description;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    int32 StageCount = 1;
+};
+
+USTRUCT(BlueprintType)
+struct FMissionProgress
+{
+    GENERATED_BODY();
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    FName MissionId;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    int32 CurrentStage = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    bool bCompleted = false;
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FMissionUpdated, const FMissionProgress&, Progress);
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UMissionManagerComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UMissionManagerComponent();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+    virtual void BeginPlay() override;
+
+    /** Advance the specified mission to the next stage */
+    UFUNCTION(BlueprintCallable, Category="Mission")
+    void AdvanceMission(FName MissionId);
+
+    /** Retrieve mission data from table or loaded JSON */
+    UFUNCTION(BlueprintCallable, Category="Mission")
+    const FMissionData* GetMissionData(FName MissionId) const;
+
+    /** Mission data table asset */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Mission")
+    UDataTable* MissionTable = nullptr;
+
+    /** Broadcast whenever mission progress changes */
+    UPROPERTY(BlueprintAssignable)
+    FMissionUpdated OnMissionUpdated;
+
+protected:
+    UFUNCTION(Server, Reliable, WithValidation)
+    void ServerAdvanceMission(FName MissionId);
+
+    UFUNCTION()
+    void OnRep_MissionProgress();
+
+    void LoadMissionsFromJson();
+
+    /** Replicated mission progress array */
+    UPROPERTY(ReplicatedUsing=OnRep_MissionProgress)
+    TArray<FMissionProgress> MissionProgress;
+
+    /** Data parsed from JSON files */
+    UPROPERTY()
+    TArray<FMissionData> JsonMissions;
+};
+


### PR DESCRIPTION
## Summary
- add mission data-driven component
- read quests from `/Content/Quests` JSON or `UDataTable`
- replicate mission progress across the network
- document how to add quests

## Testing
- `echo "Running tests (none present)" && true`

------
https://chatgpt.com/codex/tasks/task_e_686cab27711483319ab0b512fe2af1dd