### PR TITLE
Add HUD widget and accessibility settings

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -98,4 +98,10 @@ bNativizeOnlySelectedBlueprints=False
 ; Enable project localization
 +LocalizationPaths=(Path="Content/Localization/Game")
 
+[Accessibility]
+; 0=Normal,1=Deuteranope,2=Protanope,3=Tritanope
+ColorBlindPreset=0
+SubtitleScale=1.0
+HUDScale=1.0
+
 

--- a/Content/UI/WBP_AccessibilityOptions.uasset
+++ b/Content/UI/WBP_AccessibilityOptions.uasset
@@ -1,0 +1,1 @@
+Placeholder Widget

--- a/Content/UI/WBP_HUDWidget.uasset
+++ b/Content/UI/WBP_HUDWidget.uasset
@@ -1,0 +1,1 @@
+Placeholder Widget

--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -12,7 +12,8 @@ public class ALSReplicated : ModuleRules
                         new string[] {
                                 System.IO.Path.Combine(ModuleDirectory, "Public"),
                                 System.IO.Path.Combine(ModuleDirectory, "Public/Camera"),
-                                System.IO.Path.Combine(ModuleDirectory, "Public/Environment")
+                                System.IO.Path.Combine(ModuleDirectory, "Public/Environment"),
+                                System.IO.Path.Combine(ModuleDirectory, "Public/UI")
                         }
                         );
 				
@@ -21,7 +22,8 @@ public class ALSReplicated : ModuleRules
                         new string[] {
                                 System.IO.Path.Combine(ModuleDirectory, "Private"),
                                 System.IO.Path.Combine(ModuleDirectory, "Private/Camera"),
-                                System.IO.Path.Combine(ModuleDirectory, "Private/Environment")
+                                System.IO.Path.Combine(ModuleDirectory, "Private/Environment"),
+                                System.IO.Path.Combine(ModuleDirectory, "Private/UI")
                         }
                         );
 			

--- a/Source/ALSReplicated/Private/AccessibilitySettings.cpp
+++ b/Source/ALSReplicated/Private/AccessibilitySettings.cpp
@@ -1,0 +1,6 @@
+#include "AccessibilitySettings.h"
+
+void UAccessibilitySettings::Save()
+{
+    SaveConfig();
+}

--- a/Source/ALSReplicated/Private/MenuManager.cpp
+++ b/Source/ALSReplicated/Private/MenuManager.cpp
@@ -4,6 +4,7 @@
 #include "Engine/Engine.h"
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/GameUserSettings.h"
+#include "AccessibilitySettings.h"
 
 void UMenuManager::ShowMainMenu()
 {
@@ -13,6 +14,11 @@ void UMenuManager::ShowMainMenu()
 void UMenuManager::ShowOptionsMenu()
 {
     ShowWidget(OptionsMenuClass);
+}
+
+void UMenuManager::ShowAccessibilityMenu()
+{
+    ShowWidget(AccessibilityOptionsClass);
 }
 
 void UMenuManager::ShowKeybindMenu()
@@ -26,6 +32,11 @@ void UMenuManager::SaveSettings()
     {
         Settings->ApplySettings(false);
         Settings->SaveSettings();
+    }
+
+    if (UAccessibilitySettings* AccessSettings = UAccessibilitySettings::Get())
+    {
+        AccessSettings->Save();
     }
 }
 

--- a/Source/ALSReplicated/Private/UI/HUDWidget.cpp
+++ b/Source/ALSReplicated/Private/UI/HUDWidget.cpp
@@ -1,0 +1,12 @@
+#include "UI/HUDWidget.h"
+#include "AccessibilitySettings.h"
+
+void UHUDWidget::NativeOnInitialized()
+{
+    Super::NativeOnInitialized();
+    const UAccessibilitySettings* Settings = GetDefault<UAccessibilitySettings>();
+    if (Settings)
+    {
+        SetRenderTransformScale(FVector2D(Settings->HUDScale));
+    }
+}

--- a/Source/ALSReplicated/Public/AccessibilitySettings.h
+++ b/Source/ALSReplicated/Public/AccessibilitySettings.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "AccessibilitySettings.generated.h"
+
+UENUM(BlueprintType)
+enum class EColorBlindPreset : uint8
+{
+    Normal      UMETA(DisplayName="Normal"),
+    Deuteranope UMETA(DisplayName="Deuteranope"),
+    Protanope   UMETA(DisplayName="Protanope"),
+    Tritanope   UMETA(DisplayName="Tritanope")
+};
+
+/** Stores accessibility related user settings */
+UCLASS(Config=Game, DefaultConfig, BlueprintType)
+class ALSREPLICATED_API UAccessibilitySettings : public UObject
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category="Accessibility")
+    EColorBlindPreset ColorBlindPreset = EColorBlindPreset::Normal;
+
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category="Accessibility", meta=(ClampMin="0.5", ClampMax="3.0"))
+    float SubtitleScale = 1.0f;
+
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category="Accessibility", meta=(ClampMin="0.5", ClampMax="3.0"))
+    float HUDScale = 1.0f;
+
+    UFUNCTION(BlueprintCallable, Category="Accessibility")
+    static UAccessibilitySettings* Get() { return GetMutableDefault<UAccessibilitySettings>(); }
+
+    UFUNCTION(BlueprintCallable, Category="Accessibility")
+    void Save();
+};

--- a/Source/ALSReplicated/Public/MenuManager.h
+++ b/Source/ALSReplicated/Public/MenuManager.h
@@ -20,6 +20,10 @@ public:
     UFUNCTION(BlueprintCallable, Category="Menu")
     void ShowOptionsMenu();
 
+    /** Show the accessibility options menu */
+    UFUNCTION(BlueprintCallable, Category="Menu")
+    void ShowAccessibilityMenu();
+
     /** Show the keybinding menu */
     UFUNCTION(BlueprintCallable, Category="Menu")
     void ShowKeybindMenu();
@@ -39,6 +43,9 @@ protected:
 
     UPROPERTY(EditDefaultsOnly, Category="Menu")
     TSubclassOf<UUserWidget> OptionsMenuClass;
+
+    UPROPERTY(EditDefaultsOnly, Category="Menu")
+    TSubclassOf<UUserWidget> AccessibilityOptionsClass;
 
     UPROPERTY(EditDefaultsOnly, Category="Menu")
     TSubclassOf<UUserWidget> KeybindMenuClass;

--- a/Source/ALSReplicated/Public/UI/HUDWidget.h
+++ b/Source/ALSReplicated/Public/UI/HUDWidget.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "HUDWidget.generated.h"
+
+class UAccessibilitySettings;
+
+/** Simple HUD widget that scales based on saved settings */
+UCLASS(BlueprintType)
+class ALSREPLICATED_API UHUDWidget : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    virtual void NativeOnInitialized() override;
+};


### PR DESCRIPTION
## Summary
- add placeholder HUD widget blueprint and accessibility options screen
- support HUD scaling using new `UHUDWidget` class
- implement `UAccessibilitySettings` storing color blind presets and subtitle scaling
- allow `MenuManager` to open accessibility options and save settings
- expose default accessibility settings in `DefaultGame.ini`

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686cb0d9d2bc833193b4f56cd1443fb4