### PR TITLE
Add server target and analytics component

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ A set of automation tests validates component replication and event behavior. Op
 UE4Editor.exe <YourProject>.uproject -run=Automation -test=ALSReplicated.* -unattended
 ```
 
+## Dedicated Server
+
+After compiling the `ALSReplicatedServer` target you can run a dedicated server from the command line:
+
+```
+<YourProject>Server <MapName> -log
+```
+
 ## Interactive Actor Setup
 
 Interactive objects that you intend to push, pull or otherwise move should replicate their movement. Ensure the actor has **bReplicateMovement** enabled or that you manually replicate its transform. For the best network prediction during push and pull, use a `UPrimitiveComponent` with physics simulation and call `SetPhysicsLinearVelocity` rather than directly updating the actor transform.

--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -13,7 +13,8 @@ public class ALSReplicated : ModuleRules
                                 System.IO.Path.Combine(ModuleDirectory, "Public"),
                                 System.IO.Path.Combine(ModuleDirectory, "Public/Camera"),
                                 System.IO.Path.Combine(ModuleDirectory, "Public/Environment"),
-                                System.IO.Path.Combine(ModuleDirectory, "Public/UI")
+                                System.IO.Path.Combine(ModuleDirectory, "Public/UI"),
+                                System.IO.Path.Combine(ModuleDirectory, "Public/Analytics")
                         }
                         );
 				
@@ -23,7 +24,8 @@ public class ALSReplicated : ModuleRules
                                 System.IO.Path.Combine(ModuleDirectory, "Private"),
                                 System.IO.Path.Combine(ModuleDirectory, "Private/Camera"),
                                 System.IO.Path.Combine(ModuleDirectory, "Private/Environment"),
-                                System.IO.Path.Combine(ModuleDirectory, "Private/UI")
+                                System.IO.Path.Combine(ModuleDirectory, "Private/UI"),
+                                System.IO.Path.Combine(ModuleDirectory, "Private/Analytics")
                         }
                         );
 			
@@ -64,6 +66,15 @@ public class ALSReplicated : ModuleRules
                                // ... add private dependencies that you statically link with here ...
                         }
                         );
+
+                if (Target.Type == TargetType.Server)
+                {
+                        PublicDefinitions.Add("ALS_DEDICATED_SERVER=1");
+                }
+                else
+                {
+                        PublicDefinitions.Add("ALS_DEDICATED_SERVER=0");
+                }
 		
 		
 		DynamicallyLoadedModuleNames.AddRange(

--- a/Source/ALSReplicated/Private/Analytics/PlayerAnalyticsComponent.cpp
+++ b/Source/ALSReplicated/Private/Analytics/PlayerAnalyticsComponent.cpp
@@ -1,0 +1,35 @@
+#include "Analytics/PlayerAnalyticsComponent.h"
+#include "GameFramework/Actor.h"
+#include "ALSLog.h"
+
+UPlayerAnalyticsComponent::UPlayerAnalyticsComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UPlayerAnalyticsComponent::BeginPlay()
+{
+    Super::BeginPlay();
+    LogSessionStarted();
+}
+
+void UPlayerAnalyticsComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    LogSessionEnded();
+    Super::EndPlay(EndPlayReason);
+}
+
+void UPlayerAnalyticsComponent::LogEvent(const FString& EventName) const
+{
+    UE_LOG(LogALSReplicated, Log, TEXT("Analytics Event: %s from %s"), *EventName, *GetOwner()->GetName());
+}
+
+void UPlayerAnalyticsComponent::LogSessionStarted() const
+{
+    UE_LOG(LogALSReplicated, Log, TEXT("Analytics Session Started for %s"), *GetOwner()->GetName());
+}
+
+void UPlayerAnalyticsComponent::LogSessionEnded() const
+{
+    UE_LOG(LogALSReplicated, Log, TEXT("Analytics Session Ended for %s"), *GetOwner()->GetName());
+}

--- a/Source/ALSReplicated/Public/Analytics/PlayerAnalyticsComponent.h
+++ b/Source/ALSReplicated/Public/Analytics/PlayerAnalyticsComponent.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "PlayerAnalyticsComponent.generated.h"
+
+/** Simple analytics component that logs gameplay sessions and events */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UPlayerAnalyticsComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UPlayerAnalyticsComponent();
+
+    /** Log a custom analytics event */
+    UFUNCTION(BlueprintCallable, Category="Analytics")
+    void LogEvent(const FString& EventName) const;
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+    void LogSessionStarted() const;
+    void LogSessionEnded() const;
+};

--- a/Source/ALSReplicatedServer.Target.cs
+++ b/Source/ALSReplicatedServer.Target.cs
@@ -1,0 +1,12 @@
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class ALSReplicatedServerTarget : TargetRules
+{
+    public ALSReplicatedServerTarget(TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Server;
+        DefaultBuildSettings = BuildSettingsVersion.V2;
+        ExtraModuleNames.Add("ALSReplicated");
+    }
+}


### PR DESCRIPTION
## Summary
- support analytics with `UPlayerAnalyticsComponent`
- add server build definitions and include paths
- add `ALSReplicatedServer` target file
- document how to run a dedicated server

## Testing
- `echo "No tests present" && true`

------
https://chatgpt.com/codex/tasks/task_e_686cb6557a088331bf5fb395af862062