### PR TITLE
Add localized log messages

### DIFF
--- a/Content/Localization/Game/Game.manifest
+++ b/Content/Localization/Game/Game.manifest
@@ -11,6 +11,10 @@
         { "Namespace": "", "Source": "Interactive actor {0} is not set to replicate.", "Key": "InteractiveActorNotReplicated" },
         { "Namespace": "", "Source": "Interactive actor {0} missing bReplicateMovement.", "Key": "InteractiveActorMissingReplicateMovement" },
         { "Namespace": "", "Source": "SpawnDirectionalNiagaraFX: Invalid world context object", "Key": "SpawnDirectionalNiagaraFX_InvalidWorld" },
-        { "Namespace": "", "Source": "SpawnImpactDecal: Invalid world context object", "Key": "SpawnImpactDecal_InvalidWorld" }
+        { "Namespace": "", "Source": "SpawnImpactDecal: Invalid world context object", "Key": "SpawnImpactDecal_InvalidWorld" },
+        { "Namespace": "", "Source": "{0} is calling for backup!", "Key": "AI_CallBackup_Log" },
+        { "Namespace": "", "Source": "Analytics Event: {0} from {1}", "Key": "AnalyticsEventLog" },
+        { "Namespace": "", "Source": "Analytics Session Started for {0}", "Key": "AnalyticsSessionStarted" },
+        { "Namespace": "", "Source": "Analytics Session Ended for {0}", "Key": "AnalyticsSessionEnded" }
     ]
 }

--- a/Content/Localization/Game/en/Game.archive
+++ b/Content/Localization/Game/en/Game.archive
@@ -11,6 +11,10 @@
         { "Namespace": "", "Key": "InteractiveActorNotReplicated", "Source": "Interactive actor {0} is not set to replicate.", "Translation": "Interactive actor {0} is not set to replicate." },
         { "Namespace": "", "Key": "InteractiveActorMissingReplicateMovement", "Source": "Interactive actor {0} missing bReplicateMovement.", "Translation": "Interactive actor {0} missing bReplicateMovement." },
         { "Namespace": "", "Key": "SpawnDirectionalNiagaraFX_InvalidWorld", "Source": "SpawnDirectionalNiagaraFX: Invalid world context object", "Translation": "SpawnDirectionalNiagaraFX: Invalid world context object" },
-        { "Namespace": "", "Key": "SpawnImpactDecal_InvalidWorld", "Source": "SpawnImpactDecal: Invalid world context object", "Translation": "SpawnImpactDecal: Invalid world context object" }
+        { "Namespace": "", "Key": "SpawnImpactDecal_InvalidWorld", "Source": "SpawnImpactDecal: Invalid world context object", "Translation": "SpawnImpactDecal: Invalid world context object" },
+        { "Namespace": "", "Key": "AI_CallBackup_Log", "Source": "{0} is calling for backup!", "Translation": "{0} is calling for backup!" },
+        { "Namespace": "", "Key": "AnalyticsEventLog", "Source": "Analytics Event: {0} from {1}", "Translation": "Analytics Event: {0} from {1}" },
+        { "Namespace": "", "Key": "AnalyticsSessionStarted", "Source": "Analytics Session Started for {0}", "Translation": "Analytics Session Started for {0}" },
+        { "Namespace": "", "Key": "AnalyticsSessionEnded", "Source": "Analytics Session Ended for {0}", "Translation": "Analytics Session Ended for {0}" }
     ]
 }

--- a/Source/ALSReplicated/Private/AI/Tasks/BTTask_CallBackup.cpp
+++ b/Source/ALSReplicated/Private/AI/Tasks/BTTask_CallBackup.cpp
@@ -18,7 +18,9 @@ EBTNodeResult::Type UBTTask_CallBackup::ExecuteTask(UBehaviorTreeComponent& Owne
 
     if (AActor* OwnerActor = Controller->GetPawn())
     {
-        UE_LOG(LogALSReplicated, Warning, TEXT("%s is calling for backup!"), *OwnerActor->GetName());
+        UE_LOG(LogALSReplicated, Warning, TEXT("%s"), *FText::Format(
+            LOCTEXT("AI_CallBackup_Log", "{0} is calling for backup!"),
+            FText::FromString(OwnerActor->GetName())).ToString());
     }
 
     return EBTNodeResult::Succeeded;

--- a/Source/ALSReplicated/Private/Analytics/PlayerAnalyticsComponent.cpp
+++ b/Source/ALSReplicated/Private/Analytics/PlayerAnalyticsComponent.cpp
@@ -21,15 +21,22 @@ void UPlayerAnalyticsComponent::EndPlay(const EEndPlayReason::Type EndPlayReason
 
 void UPlayerAnalyticsComponent::LogEvent(const FString& EventName) const
 {
-    UE_LOG(LogALSReplicated, Log, TEXT("Analytics Event: %s from %s"), *EventName, *GetOwner()->GetName());
+    UE_LOG(LogALSReplicated, Log, TEXT("%s"), *FText::Format(
+        LOCTEXT("AnalyticsEventLog", "Analytics Event: {0} from {1}"),
+        FText::FromString(EventName),
+        FText::FromString(GetOwner()->GetName())).ToString());
 }
 
 void UPlayerAnalyticsComponent::LogSessionStarted() const
 {
-    UE_LOG(LogALSReplicated, Log, TEXT("Analytics Session Started for %s"), *GetOwner()->GetName());
+    UE_LOG(LogALSReplicated, Log, TEXT("%s"), *FText::Format(
+        LOCTEXT("AnalyticsSessionStarted", "Analytics Session Started for {0}"),
+        FText::FromString(GetOwner()->GetName())).ToString());
 }
 
 void UPlayerAnalyticsComponent::LogSessionEnded() const
 {
-    UE_LOG(LogALSReplicated, Log, TEXT("Analytics Session Ended for %s"), *GetOwner()->GetName());
+    UE_LOG(LogALSReplicated, Log, TEXT("%s"), *FText::Format(
+        LOCTEXT("AnalyticsSessionEnded", "Analytics Session Ended for {0}"),
+        FText::FromString(GetOwner()->GetName())).ToString());
 }


### PR DESCRIPTION
## Summary
- use `LOCTEXT` for analytics logging and call backup behavior
- add new strings to localization manifest and archive

## Testing
- `RunUAT.sh -run=AutomationTests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686cbf4f15648331820e6f0258bf2e07