### PR TITLE
Add adaptive music component with localization

### DIFF
--- a/Config/Localization.ini
+++ b/Config/Localization.ini
@@ -1,0 +1,11 @@
+[CommonSettings]
+SourcePath=Content/Localization
+DestinationPath=Content/Localization
+ManifestName=Game
+ArchiveName=Game
+bEnableTranslationExport=True
+bEnableTranslationImport=True
+bCSVExport=True
+
+[GatherTextStep0]
+CommandletClass=GatherTextCommandlet

--- a/Content/Audio/Combat_Cue.uasset
+++ b/Content/Audio/Combat_Cue.uasset
@@ -1,0 +1,1 @@
+Placeholder combat cue

--- a/Content/Audio/Exploration_Cue.uasset
+++ b/Content/Audio/Exploration_Cue.uasset
@@ -1,0 +1,1 @@
+Placeholder exploration cue

--- a/Content/Audio/Stinger_Cue.uasset
+++ b/Content/Audio/Stinger_Cue.uasset
@@ -1,0 +1,1 @@
+Placeholder stinger cue

--- a/Content/Localization/Audio/AdaptiveMusic.csv
+++ b/Content/Localization/Audio/AdaptiveMusic.csv
@@ -1,0 +1,3 @@
+Key,SourceString
+CombatCueDesc,Intense Combat Music
+ExplorationCueDesc,Calm Exploration Music

--- a/README.md
+++ b/README.md
@@ -140,3 +140,23 @@ Quests are read from DataTable or JSON assets located under `Content/Quests`. Ea
 2. Add `UMissionManagerComponent` (or `BP_MissionManagerComponent`) to your player character.
 3. Call `AdvanceMission` from Blueprint or code to update progress. Mission progress replicates automatically for all clients.
 
+
+## Localization
+
+Strings for UI and audio are maintained in CSV files under `Content/Localization`.
+An example file `Audio/AdaptiveMusic.csv` is included:
+
+```
+Key,SourceString
+CombatCueDesc,Intense Combat Music
+ExplorationCueDesc,Calm Exploration Music
+```
+
+Run the localization commandlet to generate the manifest and archives:
+
+```
+UE4Editor-Cmd.exe <YourProject>.uproject -run=GatherText -config=Config/Localization.ini
+```
+
+After translating the CSVs run the commandlet again to compile `.locres` files.
+Localized text will then be available through the standard `FText` system.

--- a/Source/ALSReplicated/ALSReplicated.Build.cs
+++ b/Source/ALSReplicated/ALSReplicated.Build.cs
@@ -63,9 +63,10 @@ public class ALSReplicated : ModuleRules
                                "CableComponent",
                                "Json",
                                "JsonUtilities",
+                               "AudioMixer",
                                // ... add private dependencies that you statically link with here ...
-                        }
-                        );
+                       }
+                       );
 
                 if (Target.Type == TargetType.Server)
                 {

--- a/Source/ALSReplicated/Private/AdaptiveMusicComponent.cpp
+++ b/Source/ALSReplicated/Private/AdaptiveMusicComponent.cpp
@@ -1,0 +1,50 @@
+#include "AdaptiveMusicComponent.h"
+#include "Components/AudioComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Sound/SoundBase.h"
+
+UAdaptiveMusicComponent::UAdaptiveMusicComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UAdaptiveMusicComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (AActor* Owner = GetOwner())
+    {
+        StateCoordinator = Owner->FindComponentByClass<UCharacterStateCoordinator>();
+        if (StateCoordinator)
+        {
+            StateCoordinator->OnStateChanged.AddDynamic(this, &UAdaptiveMusicComponent::HandleStateChanged);
+            HandleStateChanged(StateCoordinator->GetCharacterState());
+        }
+    }
+}
+
+void UAdaptiveMusicComponent::HandleStateChanged(ECharacterActivityState NewState)
+{
+    USoundBase* Cue = (NewState == ECharacterActivityState::Combat) ? CombatCue : ExplorationCue;
+    PlayCue(Cue);
+}
+
+void UAdaptiveMusicComponent::PlayCue(USoundBase* Cue)
+{
+    if (CurrentComponent)
+    {
+        CurrentComponent->FadeOut(FadeDuration, 0.f);
+        CurrentComponent->bAutoDestroy = true;
+        CurrentComponent = nullptr;
+    }
+
+    if (Cue)
+    {
+        CurrentComponent = UGameplayStatics::SpawnSoundAttached(Cue, GetOwner()->GetRootComponent());
+        if (CurrentComponent)
+        {
+            CurrentComponent->FadeIn(FadeDuration, 1.f);
+        }
+    }
+}
+

--- a/Source/ALSReplicated/Public/AdaptiveMusicComponent.h
+++ b/Source/ALSReplicated/Public/AdaptiveMusicComponent.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "CharacterStateCoordinator.h"
+#include "AdaptiveMusicComponent.generated.h"
+
+class UAudioComponent;
+class USoundBase;
+
+/**
+ * Plays different music cues depending on the current character activity state.
+ */
+UCLASS(ClassGroup=(Audio), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UAdaptiveMusicComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UAdaptiveMusicComponent();
+
+protected:
+    virtual void BeginPlay() override;
+
+    UFUNCTION()
+    void HandleStateChanged(ECharacterActivityState NewState);
+
+    void PlayCue(USoundBase* Cue);
+
+    UPROPERTY(EditDefaultsOnly, Category="Adaptive Music")
+    USoundBase* ExplorationCue;
+
+    UPROPERTY(EditDefaultsOnly, Category="Adaptive Music")
+    USoundBase* CombatCue;
+
+    UPROPERTY(EditDefaultsOnly, Category="Adaptive Music")
+    float FadeDuration = 1.f;
+
+    UPROPERTY()
+    UAudioComponent* CurrentComponent = nullptr;
+
+    UPROPERTY()
+    UCharacterStateCoordinator* StateCoordinator = nullptr;
+};
+


### PR DESCRIPTION
## Summary
- add `UAdaptiveMusicComponent` that listens to `UCharacterStateCoordinator`
- expand plugin build.cs with the `AudioMixer` module
- provide a sample localization pipeline and CSV
- include placeholder sound cues in `Content/Audio`
- document the localization workflow in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686cc3bbd8648331a507694b4836cba3