### PR TITLE
Add EndPlay and delegate cleanup in AI controller

### DIFF
--- a/Source/ALSReplicated/Private/AI/AAAController.cpp
+++ b/Source/ALSReplicated/Private/AI/AAAController.cpp
@@ -88,3 +88,28 @@ void AALSBaseAIController::HandleHardImpact(AActor* Instigator, FVector Location
     }
 }
 
+void AALSBaseAIController::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (UWorld* World = GetWorld())
+    {
+        if (UImpactEventSubsystem* Subsystem = World->GetSubsystem<UImpactEventSubsystem>())
+        {
+            Subsystem->OnHardImpact.RemoveDynamic(this, &AALSBaseAIController::HandleHardImpact);
+        }
+    }
+    Super::EndPlay(EndPlayReason);
+}
+
+void AALSBaseAIController::OnUnPossess()
+{
+    if (UWorld* World = GetWorld())
+    {
+        if (UImpactEventSubsystem* Subsystem = World->GetSubsystem<UImpactEventSubsystem>())
+        {
+            Subsystem->OnHardImpact.RemoveDynamic(this, &AALSBaseAIController::HandleHardImpact);
+        }
+    }
+
+    Super::OnUnPossess();
+}
+

--- a/Source/ALSReplicated/Public/AI/AAAController.h
+++ b/Source/ALSReplicated/Public/AI/AAAController.h
@@ -24,6 +24,9 @@ public:
     virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
     virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+    virtual void OnUnPossess() override;
 
 protected:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="AI")


### PR DESCRIPTION
## Summary
- declare EndPlay and OnUnPossess overrides for the base AI controller
- remove HardImpact delegate when the controller ends play or unpossesses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ccc68795c83319419c09f4f03f719