### PR TITLE
Add WithValidation for movement RPCs

### DIFF
--- a/Source/ALSReplicated/Private/ALSCharacterMovementComponent.cpp
+++ b/Source/ALSReplicated/Private/ALSCharacterMovementComponent.cpp
@@ -16,74 +16,128 @@ void UALSCharacterMovementComponent::GetLifetimeReplicatedProps(TArray<FLifetime
 
 void UALSCharacterMovementComponent::SetMaxWalkSpeed(float Max_WalkSpeed)
 {
-	NewMaxWalkSpeed = Max_WalkSpeed;
-	Server_MaxWalkSpeed_Implementation(NewMaxWalkSpeed);
-	MaxWalkSpeed = NewMaxWalkSpeed;
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        Server_MaxWalkSpeed(Max_WalkSpeed);
+        return;
+    }
+    NewMaxWalkSpeed = Max_WalkSpeed;
+    MaxWalkSpeed = NewMaxWalkSpeed;
 }
 
 void UALSCharacterMovementComponent::SetMaxWalkSpeedCrouched(float Max_WalkSpeedCrouched)
 {
-        NewMaxWalkSpeedCrouched = Max_WalkSpeedCrouched;
-        Server_MaxWalkSpeedCrouched_Implementation(NewMaxWalkSpeedCrouched);
-        MaxWalkSpeedCrouched = NewMaxWalkSpeedCrouched;
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        Server_MaxWalkSpeedCrouched(Max_WalkSpeedCrouched);
+        return;
+    }
+    NewMaxWalkSpeedCrouched = Max_WalkSpeedCrouched;
+    MaxWalkSpeedCrouched = NewMaxWalkSpeedCrouched;
 }
 
 void UALSCharacterMovementComponent::SetMaxAcceleration(float Max_Acceleration)
 {
-	NewMaxAcceleration = Max_Acceleration;
-	Server_MaxAcceleration_Implementation(Max_Acceleration);
-	MaxAcceleration = NewMaxAcceleration;
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        Server_MaxAcceleration(Max_Acceleration);
+        return;
+    }
+    NewMaxAcceleration = Max_Acceleration;
+    MaxAcceleration = NewMaxAcceleration;
 }
 
 void UALSCharacterMovementComponent::SetBrakingDecelerationWalking(float Braking_DecelerationWalking)
 {
-	NewBrakingDecelerationWalking = Braking_DecelerationWalking;
-	Server_BrakingDecelerationWalking_Implementation(NewBrakingDecelerationWalking);
-	BrakingDecelerationWalking = NewBrakingDecelerationWalking;
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        Server_BrakingDecelerationWalking(Braking_DecelerationWalking);
+        return;
+    }
+    NewBrakingDecelerationWalking = Braking_DecelerationWalking;
+    BrakingDecelerationWalking = NewBrakingDecelerationWalking;
 }
 
 void UALSCharacterMovementComponent::SetGroundFriction(float Ground_Friction)
 {
-	NewGroundFriction = Ground_Friction;
-	Server_GroundFriction_Implementation(NewGroundFriction);
-	GroundFriction = NewGroundFriction;
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        Server_GroundFriction(Ground_Friction);
+        return;
+    }
+    NewGroundFriction = Ground_Friction;
+    GroundFriction = NewGroundFriction;
 }
 
 void UALSCharacterMovementComponent::SetBrakingFrictionFactor(float Braking_FrictionFactor)
 {
-        NewBrakingFrictionFactor = Braking_FrictionFactor;
-        Server_BrakingFrictionFactor_Implementation(NewBrakingFrictionFactor);
-        BrakingFrictionFactor = NewBrakingFrictionFactor;
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        Server_BrakingFrictionFactor(Braking_FrictionFactor);
+        return;
+    }
+    NewBrakingFrictionFactor = Braking_FrictionFactor;
+    BrakingFrictionFactor = NewBrakingFrictionFactor;
 }
 
 void UALSCharacterMovementComponent::Server_MaxWalkSpeed_Implementation(float Max_WalkSpeed)
 {
-	NewMaxWalkSpeed = Max_WalkSpeed;
+    SetMaxWalkSpeed(Max_WalkSpeed);
 }
 
 void UALSCharacterMovementComponent::Server_MaxWalkSpeedCrouched_Implementation(float Max_WalkSpeedCrouched)
 {
-        MaxWalkSpeedCrouched = Max_WalkSpeedCrouched;
+    SetMaxWalkSpeedCrouched(Max_WalkSpeedCrouched);
 }
 
 void UALSCharacterMovementComponent::Server_MaxAcceleration_Implementation(float Max_Acceleration)
 {
-	NewMaxAcceleration = Max_Acceleration;
+    SetMaxAcceleration(Max_Acceleration);
 }
 
 void UALSCharacterMovementComponent::Server_BrakingDecelerationWalking_Implementation(float Braking_DecelerationWalking)
 {
-	NewBrakingDecelerationWalking = Braking_DecelerationWalking;
+    SetBrakingDecelerationWalking(Braking_DecelerationWalking);
 }
 
 void UALSCharacterMovementComponent::Server_GroundFriction_Implementation(float Ground_Friction)
 {
-	NewGroundFriction = Ground_Friction;
+    SetGroundFriction(Ground_Friction);
 }
 
 void UALSCharacterMovementComponent::Server_BrakingFrictionFactor_Implementation(float Braking_FrictionFactor)
 {
-        NewBrakingFrictionFactor = Braking_FrictionFactor;
+    SetBrakingFrictionFactor(Braking_FrictionFactor);
+}
+
+bool UALSCharacterMovementComponent::Server_MaxWalkSpeed_Validate(float Max_WalkSpeed)
+{
+    return GetOwner() && GetOwner()->HasAuthority() && FMath::IsFinite(Max_WalkSpeed) && Max_WalkSpeed >= 0.f;
+}
+
+bool UALSCharacterMovementComponent::Server_MaxWalkSpeedCrouched_Validate(float Max_WalkSpeedCrouched)
+{
+    return GetOwner() && GetOwner()->HasAuthority() && FMath::IsFinite(Max_WalkSpeedCrouched) && Max_WalkSpeedCrouched >= 0.f;
+}
+
+bool UALSCharacterMovementComponent::Server_MaxAcceleration_Validate(float Max_Acceleration)
+{
+    return GetOwner() && GetOwner()->HasAuthority() && FMath::IsFinite(Max_Acceleration) && Max_Acceleration >= 0.f;
+}
+
+bool UALSCharacterMovementComponent::Server_BrakingDecelerationWalking_Validate(float Braking_DecelerationWalking)
+{
+    return GetOwner() && GetOwner()->HasAuthority() && FMath::IsFinite(Braking_DecelerationWalking) && Braking_DecelerationWalking >= 0.f;
+}
+
+bool UALSCharacterMovementComponent::Server_GroundFriction_Validate(float Ground_Friction)
+{
+    return GetOwner() && GetOwner()->HasAuthority() && FMath::IsFinite(Ground_Friction) && Ground_Friction >= 0.f;
+}
+
+bool UALSCharacterMovementComponent::Server_BrakingFrictionFactor_Validate(float Braking_FrictionFactor)
+{
+    return GetOwner() && GetOwner()->HasAuthority() && FMath::IsFinite(Braking_FrictionFactor) && Braking_FrictionFactor >= 0.f;
 }
 
 void UALSCharacterMovementComponent::OnRep_NewMaxWalkSpeed()

--- a/Source/ALSReplicated/Public/ALSCharacterMovementComponent.h
+++ b/Source/ALSReplicated/Public/ALSCharacterMovementComponent.h
@@ -73,23 +73,23 @@ private:
        UPROPERTY(ReplicatedUsing=OnRep_NewBrakingFrictionFactor)
        float NewBrakingFrictionFactor = BrakingFrictionFactor;
 
-	UFUNCTION(Server, Reliable)
-	void Server_MaxWalkSpeed(float Max_WalkSpeed);
+         UFUNCTION(Server, Reliable, WithValidation)
+         void Server_MaxWalkSpeed(float Max_WalkSpeed);
 
-	UFUNCTION(Server, Reliable)
-        void Server_MaxWalkSpeedCrouched(float Max_WalkSpeedCrouched);
+         UFUNCTION(Server, Reliable, WithValidation)
+         void Server_MaxWalkSpeedCrouched(float Max_WalkSpeedCrouched);
 
-	UFUNCTION(Server, Reliable)
-	void Server_MaxAcceleration(float Max_Acceleration);
+         UFUNCTION(Server, Reliable, WithValidation)
+         void Server_MaxAcceleration(float Max_Acceleration);
 
-	UFUNCTION(Server, Reliable)
-	void Server_BrakingDecelerationWalking(float Braking_DecelerationWalking);
+         UFUNCTION(Server, Reliable, WithValidation)
+         void Server_BrakingDecelerationWalking(float Braking_DecelerationWalking);
 
-	UFUNCTION(Server, Reliable)
-	void Server_GroundFriction(float Ground_Friction);
+         UFUNCTION(Server, Reliable, WithValidation)
+         void Server_GroundFriction(float Ground_Friction);
 
-	UFUNCTION(Server, Reliable)
-        void Server_BrakingFrictionFactor(float Braking_FrictionFactor);
+         UFUNCTION(Server, Reliable, WithValidation)
+         void Server_BrakingFrictionFactor(float Braking_FrictionFactor);
 	
 };
 


### PR DESCRIPTION
## Summary
- add validation to movement server RPCs
- verify `HasAuthority` and parameter ranges in new `_Validate` methods
- route Set functions through their server RPCs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ccee6315c83319b5d64d84c290430