### PR TITLE
Add save game component

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,15 @@ UE4Editor-Cmd.exe <YourProject>.uproject -run=GatherText -config=Config/Localiza
 
 After translating the CSVs run the commandlet again to compile `.locres` files.
 Localized text will then be available through the standard `FText` system.
+
+## Save System
+
+`USaveGameComponent` serializes player stamina, mission progress, and environment state. Attach it to the player character and call its functions to persist data.
+
+```cpp
+USaveGameComponent* SaveComp = Character->FindComponentByClass<USaveGameComponent>();
+SaveComp->SaveGame();
+SaveComp->LoadGame();
+```
+
+The component creates a `UPlayerSaveGame` object and uses `UGameplayStatics::SaveGameToSlot` and `LoadGameFromSlot` under the hood. Mission completions broadcast by `UMissionManagerComponent` and traversal actions from `UCharacterStateCoordinator` automatically trigger an autosave.

--- a/Source/ALSReplicated/Private/SaveGameComponent.cpp
+++ b/Source/ALSReplicated/Private/SaveGameComponent.cpp
@@ -1,0 +1,133 @@
+#include "SaveGameComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "StaminaComponent.h"
+#include "AtmosphereManager.h"
+#include "CharacterStateCoordinator.h"
+#include "GameFramework/Actor.h"
+#include "EngineUtils.h"
+
+USaveGameComponent::USaveGameComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void USaveGameComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    MissionManager = GetOwner()->FindComponentByClass<UMissionManagerComponent>();
+    if (MissionManager)
+    {
+        MissionManager->OnMissionUpdated.AddDynamic(this, &USaveGameComponent::HandleMissionUpdate);
+    }
+
+    if (UCharacterStateCoordinator* Coord = GetOwner()->FindComponentByClass<UCharacterStateCoordinator>())
+    {
+        Coord->OnTraversalAction.AddDynamic(this, &USaveGameComponent::Autosave);
+    }
+}
+
+void USaveGameComponent::SaveGame()
+{
+    UPlayerSaveGame* Save = Cast<UPlayerSaveGame>(UGameplayStatics::CreateSaveGameObject(UPlayerSaveGame::StaticClass()));
+    if (!Save)
+    {
+        return;
+    }
+    GatherSaveData(Save);
+    UGameplayStatics::SaveGameToSlot(Save, SlotName, UserIndex);
+}
+
+void USaveGameComponent::LoadGame()
+{
+    if (USaveGame* Loaded = UGameplayStatics::LoadGameFromSlot(SlotName, UserIndex))
+    {
+        if (UPlayerSaveGame* Save = Cast<UPlayerSaveGame>(Loaded))
+        {
+            ApplySaveData(Save);
+        }
+    }
+}
+
+void USaveGameComponent::HandleMissionUpdate(const FMissionProgress& Progress)
+{
+    if (Progress.bCompleted)
+    {
+        Autosave();
+    }
+}
+
+void USaveGameComponent::Autosave()
+{
+    SaveGame();
+}
+
+void USaveGameComponent::GatherSaveData(UPlayerSaveGame* Save) const
+{
+    if (!Save)
+    {
+        return;
+    }
+
+    if (UStaminaComponent* Stamina = GetOwner()->FindComponentByClass<UStaminaComponent>())
+    {
+        Save->Stamina = Stamina->Stamina;
+        Save->MaxStamina = Stamina->MaxStamina;
+    }
+
+    if (MissionManager)
+    {
+        Save->Missions = MissionManager->MissionProgress;
+    }
+
+    UAtmosphereManager* Atmos = GetOwner()->FindComponentByClass<UAtmosphereManager>();
+    if (!Atmos)
+    {
+        for (TActorIterator<AActor> It(GetWorld()); It && !Atmos; ++It)
+        {
+            Atmos = (*It)->FindComponentByClass<UAtmosphereManager>();
+        }
+    }
+    if (Atmos)
+    {
+        Save->TimeOfDay = Atmos->TimeOfDay;
+        Save->bRaining = Atmos->bRaining;
+        Save->bFoggy = Atmos->bFoggy;
+    }
+}
+
+void USaveGameComponent::ApplySaveData(UPlayerSaveGame* Save) const
+{
+    if (!Save)
+    {
+        return;
+    }
+
+    if (UStaminaComponent* Stamina = GetOwner()->FindComponentByClass<UStaminaComponent>())
+    {
+        Stamina->SetMaxStamina(Save->MaxStamina);
+        Stamina->Stamina = FMath::Clamp(Save->Stamina, 0.f, Save->MaxStamina);
+    }
+
+    if (MissionManager)
+    {
+        MissionManager->MissionProgress = Save->Missions;
+        MissionManager->OnRep_MissionProgress();
+    }
+
+    UAtmosphereManager* Atmos = GetOwner()->FindComponentByClass<UAtmosphereManager>();
+    if (!Atmos)
+    {
+        for (TActorIterator<AActor> It(GetWorld()); It && !Atmos; ++It)
+        {
+            Atmos = (*It)->FindComponentByClass<UAtmosphereManager>();
+        }
+    }
+    if (Atmos)
+    {
+        Atmos->SetTimeOfDay(Save->TimeOfDay);
+        Atmos->SetRaining(Save->bRaining);
+        Atmos->SetFoggy(Save->bFoggy);
+    }
+}
+

--- a/Source/ALSReplicated/Public/SaveGameComponent.h
+++ b/Source/ALSReplicated/Public/SaveGameComponent.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "GameFramework/SaveGame.h"
+#include "MissionManagerComponent.h"
+#include "SaveGameComponent.generated.h"
+
+/** Save data container for player stats and world state */
+UCLASS()
+class ALSREPLICATED_API UPlayerSaveGame : public USaveGame
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY()
+    float Stamina = 100.f;
+
+    UPROPERTY()
+    float MaxStamina = 100.f;
+
+    UPROPERTY()
+    TArray<FMissionProgress> Missions;
+
+    UPROPERTY()
+    float TimeOfDay = 12.f;
+
+    UPROPERTY()
+    bool bRaining = false;
+
+    UPROPERTY()
+    bool bFoggy = false;
+};
+
+/** Component that handles saving and loading player progress */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API USaveGameComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    USaveGameComponent();
+
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SaveGame();
+
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void LoadGame();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Save")
+    FString SlotName = TEXT("PlayerSave");
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Save")
+    uint32 UserIndex = 0;
+
+protected:
+    virtual void BeginPlay() override;
+
+    UFUNCTION()
+    void HandleMissionUpdate(const FMissionProgress& Progress);
+
+    UFUNCTION()
+    void Autosave();
+
+    void GatherSaveData(UPlayerSaveGame* Save) const;
+    void ApplySaveData(UPlayerSaveGame* Save) const;
+
+    UPROPERTY()
+    UMissionManagerComponent* MissionManager = nullptr;
+};
+


### PR DESCRIPTION
## Summary
- add `USaveGameComponent` and `UPlayerSaveGame` for serializing player progress
- autosave after mission completion or traversal events
- document saving and loading in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6872c3b8321083318cc45c597d2e1d30