### PR TITLE
Add HUD interface and health component

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,13 @@ SaveComp->LoadGame();
 ```
 
 The component creates a `UPlayerSaveGame` object and uses `UGameplayStatics::SaveGameToSlot` and `LoadGameFromSlot` under the hood. Mission completions broadcast by `UMissionManagerComponent` and traversal actions from `UCharacterStateCoordinator` automatically trigger an autosave.
+
+## HUD Widget
+
+`UHUDWidget` implements the `HUDUpdateInterface` so game systems can update player UI from Blueprints or code. The widget exposes events for:
+
+* **Health** and **Stamina** &ndash; call `UpdateHealth` and `UpdateStamina` whenever values change.
+* **Lock-on Target** &ndash; `UpdateLockOnTarget` receives the pawn currently locked-on or `None` when released.
+* **Quest Progress** &ndash; `UpdateQuest` uses the `FMissionProgress` struct from `UMissionManagerComponent`.
+
+On initialization the widget applies accessibility settings like HUD scale, subtitle size and color blind preset via `OnAccessibilitySettingsChanged` so new elements match the user's preferences.

--- a/Source/ALSReplicated/Private/HealthComponent.cpp
+++ b/Source/ALSReplicated/Private/HealthComponent.cpp
@@ -1,0 +1,66 @@
+#include "HealthComponent.h"
+
+UHealthComponent::UHealthComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+    SetIsReplicatedByDefault(true);
+}
+
+void UHealthComponent::BeginPlay()
+{
+    Super::BeginPlay();
+    Health = MaxHealth;
+    bWasDead = Health <= 0.f;
+}
+
+void UHealthComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UHealthComponent, Health);
+    DOREPLIFETIME(UHealthComponent, MaxHealth);
+}
+
+void UHealthComponent::AddHealth(float Amount)
+{
+    const bool bBefore = Health <= 0.f;
+    Health = FMath::Clamp(Health + Amount, 0.f, MaxHealth);
+    OnRep_Health();
+    OnHealthChanged.Broadcast(Health);
+    if (bBefore && Health > 0.f)
+    {
+        OnRevived.Broadcast();
+    }
+    else if (!bBefore && Health <= 0.f)
+    {
+        OnDeath.Broadcast();
+    }
+}
+
+void UHealthComponent::SetMaxHealth(float NewMax)
+{
+    MaxHealth = NewMax;
+    Health = FMath::Clamp(Health, 0.f, MaxHealth);
+    OnRep_MaxHealth();
+    OnHealthChanged.Broadcast(Health);
+}
+
+void UHealthComponent::OnRep_Health()
+{
+    bool bDead = Health <= 0.f;
+    if (bDead && !bWasDead)
+    {
+        OnDeath.Broadcast();
+    }
+    else if (!bDead && bWasDead)
+    {
+        OnRevived.Broadcast();
+    }
+    OnHealthChanged.Broadcast(Health);
+    bWasDead = bDead;
+}
+
+void UHealthComponent::OnRep_MaxHealth()
+{
+    Health = FMath::Clamp(Health, 0.f, MaxHealth);
+}
+

--- a/Source/ALSReplicated/Private/StaminaComponent.cpp
+++ b/Source/ALSReplicated/Private/StaminaComponent.cpp
@@ -25,6 +25,7 @@ void UStaminaComponent::AddStamina(float Amount)
     const bool bBefore = Stamina <= 0.f;
     Stamina = FMath::Clamp(Stamina + Amount, 0.f, MaxStamina);
     OnRep_Stamina();
+    OnStaminaChanged.Broadcast(Stamina);
     if (bBefore && Stamina > 0.f)
     {
         OnStaminaRecovered.Broadcast();
@@ -53,12 +54,14 @@ void UStaminaComponent::OnRep_Stamina()
     {
         OnStaminaRecovered.Broadcast();
     }
+    OnStaminaChanged.Broadcast(Stamina);
     bWasExhausted = bExhausted;
 }
 
 void UStaminaComponent::OnRep_MaxStamina()
 {
     Stamina = FMath::Clamp(Stamina, 0.f, MaxStamina);
+    OnStaminaChanged.Broadcast(Stamina);
 }
 
 

--- a/Source/ALSReplicated/Private/UI/HUDWidget.cpp
+++ b/Source/ALSReplicated/Private/UI/HUDWidget.cpp
@@ -1,5 +1,6 @@
 #include "UI/HUDWidget.h"
 #include "AccessibilitySettings.h"
+#include "GameFramework/Pawn.h"
 
 void UHUDWidget::NativeOnInitialized()
 {
@@ -8,5 +9,26 @@ void UHUDWidget::NativeOnInitialized()
     if (Settings)
     {
         SetRenderTransformScale(FVector2D(Settings->HUDScale));
+        OnAccessibilitySettingsChanged(Settings->ColorBlindPreset, Settings->SubtitleScale);
     }
+}
+
+void UHUDWidget::UpdateHealth_Implementation(float NewHealth)
+{
+    OnHealthChanged(NewHealth);
+}
+
+void UHUDWidget::UpdateStamina_Implementation(float NewStamina)
+{
+    OnStaminaChanged(NewStamina);
+}
+
+void UHUDWidget::UpdateLockOnTarget_Implementation(APawn* Target)
+{
+    OnLockOnTargetChanged(Target);
+}
+
+void UHUDWidget::UpdateQuest_Implementation(const FMissionProgress& Progress)
+{
+    OnQuestProgress(Progress);
 }

--- a/Source/ALSReplicated/Public/HealthComponent.h
+++ b/Source/ALSReplicated/Public/HealthComponent.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "HealthComponent.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FHealthEvent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FHealthChanged, float, NewHealth);
+
+/** Replicated component storing current and max health */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class ALSREPLICATED_API UHealthComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UHealthComponent();
+
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    /** Adds the specified amount to health (negative to damage). */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    void AddHealth(float Amount);
+
+    /** Change the maximum health value */
+    UFUNCTION(BlueprintCallable, Category="Health")
+    void SetMaxHealth(float NewMax);
+
+    /** Current health value */
+    UPROPERTY(ReplicatedUsing=OnRep_Health, BlueprintReadOnly, Category="Health")
+    float Health = 100.f;
+
+    /** Maximum health value */
+    UPROPERTY(ReplicatedUsing=OnRep_MaxHealth, EditDefaultsOnly, BlueprintReadOnly, Category="Health")
+    float MaxHealth = 100.f;
+
+    /** Fired when health reaches zero */
+    UPROPERTY(BlueprintAssignable)
+    FHealthEvent OnDeath;
+
+    /** Fired when health is recovered from zero */
+    UPROPERTY(BlueprintAssignable)
+    FHealthEvent OnRevived;
+
+    /** Fired whenever the health value changes */
+    UPROPERTY(BlueprintAssignable)
+    FHealthChanged OnHealthChanged;
+
+protected:
+    virtual void BeginPlay() override;
+
+    UFUNCTION()
+    void OnRep_Health();
+
+    UFUNCTION()
+    void OnRep_MaxHealth();
+
+    bool bWasDead = false;
+};
+

--- a/Source/ALSReplicated/Public/StaminaComponent.h
+++ b/Source/ALSReplicated/Public/StaminaComponent.h
@@ -6,6 +6,7 @@
 #include "StaminaComponent.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FStaminaEvent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FStaminaChanged, float, NewStamina);
 
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class ALSREPLICATED_API UStaminaComponent : public UActorComponent
@@ -39,6 +40,10 @@ public:
     /** Fired when stamina is recovered from zero */
     UPROPERTY(BlueprintAssignable)
     FStaminaEvent OnStaminaRecovered;
+
+    /** Fired whenever the stamina value changes */
+    UPROPERTY(BlueprintAssignable)
+    FStaminaChanged OnStaminaChanged;
 
 protected:
     virtual void BeginPlay() override;

--- a/Source/ALSReplicated/Public/UI/HUDUpdateInterface.h
+++ b/Source/ALSReplicated/Public/UI/HUDUpdateInterface.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "UObject/Interface.h"
+#include "MissionManagerComponent.h"
+#include "HUDUpdateInterface.generated.h"
+
+UINTERFACE(BlueprintType)
+class ALSREPLICATED_API UHUDUpdateInterface : public UInterface
+{
+    GENERATED_BODY()
+};
+
+class ALSREPLICATED_API IHUDUpdateInterface
+{
+    GENERATED_BODY()
+public:
+    /** Update current health value */
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="HUD")
+    void UpdateHealth(float NewHealth);
+
+    /** Update current stamina value */
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="HUD")
+    void UpdateStamina(float NewStamina);
+
+    /** Set the current lock-on target (or null to clear) */
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="HUD")
+    void UpdateLockOnTarget(APawn* Target);
+
+    /** Update quest progress */
+    UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="HUD")
+    void UpdateQuest(const FMissionProgress& Progress);
+};
+

--- a/Source/ALSReplicated/Public/UI/HUDWidget.h
+++ b/Source/ALSReplicated/Public/UI/HUDWidget.h
@@ -2,15 +2,37 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "UI/HUDUpdateInterface.h"
 #include "HUDWidget.generated.h"
 
 class UAccessibilitySettings;
 
 /** Simple HUD widget that scales based on saved settings */
 UCLASS(BlueprintType)
-class ALSREPLICATED_API UHUDWidget : public UUserWidget
+class ALSREPLICATED_API UHUDWidget : public UUserWidget, public IHUDUpdateInterface
 {
     GENERATED_BODY()
 public:
     virtual void NativeOnInitialized() override;
+
+    virtual void UpdateHealth_Implementation(float NewHealth) override;
+    virtual void UpdateStamina_Implementation(float NewStamina) override;
+    virtual void UpdateLockOnTarget_Implementation(APawn* Target) override;
+    virtual void UpdateQuest_Implementation(const FMissionProgress& Progress) override;
+
+    UFUNCTION(BlueprintImplementableEvent, Category="HUD")
+    void OnHealthChanged(float NewHealth);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="HUD")
+    void OnStaminaChanged(float NewStamina);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="HUD")
+    void OnLockOnTargetChanged(APawn* Target);
+
+    UFUNCTION(BlueprintImplementableEvent, Category="HUD")
+    void OnQuestProgress(const FMissionProgress& Progress);
+
+    /** Apply accessibility settings such as colorblind preset and subtitle scale */
+    UFUNCTION(BlueprintImplementableEvent, Category="HUD")
+    void OnAccessibilitySettingsChanged(EColorBlindPreset Preset, float SubtitleScale);
 };


### PR DESCRIPTION
## Summary
- expand `UHUDWidget` with health, stamina, lock-on and quest update events
- add `HUDUpdateInterface` for communicating with the HUD
- create a replicated `UHealthComponent`
- broadcast `OnStaminaChanged` from `UStaminaComponent`
- document the HUD widget in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872c91666488331942de634980b4185